### PR TITLE
check for filename when filtering blender builds

### DIFF
--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -87,7 +87,7 @@ class Scraper(QThread):
 
             data = json.loads(r.data)
             for build in data:
-                if build['platform'] == self.json_platform:
+                if build["platform"] == self.json_platform and self.b3d_link.match(build["file_name"]):
                     new_build = self.new_build_from_dict(build, branch_type)
                     self.links.emit(new_build)
 


### PR DESCRIPTION
This was reported by a discord user that sometimes the scraper would gather builds that use the .msi format, which we do not account for.