### PR TITLE
Cleanup Qt Signals

### DIFF
--- a/source/threads/downloader.py
+++ b/source/threads/downloader.py
@@ -6,9 +6,8 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Downloader(QThread):
-    progress_changed = pyqtSignal(
-        "PyQt_PyObject", "PyQt_PyObject", "PyQt_PyObject")
-    finished = pyqtSignal("PyQt_PyObject")
+    progress_changed = pyqtSignal(int, int)
+    finished = pyqtSignal(Path)
 
     def __init__(self, manager, link):
         QThread.__init__(self)
@@ -17,7 +16,7 @@ class Downloader(QThread):
         self.size = 0
 
     def run(self):
-        self.progress_changed.emit(0, 0, "Downloading")
+        self.progress_changed.emit(0, 0)
 
         temp_folder = Path(get_library_folder()) / ".temp"
 
@@ -32,7 +31,7 @@ class Downloader(QThread):
                                   preload_content=False) as r:
             self.size = int(r.headers["Content-Length"])
 
-            with open(dist, "wb") as f:
+            with dist.open("wb") as f:
                 copyfileobj(r, f, self.set_progress)
 
         r.release_conn()
@@ -41,4 +40,4 @@ class Downloader(QThread):
         self.finished.emit(dist)
 
     def set_progress(self, obtained):
-        self.progress_changed.emit(obtained, self.size, "Downloading")
+        self.progress_changed.emit(obtained, self.size)

--- a/source/threads/downloader.py
+++ b/source/threads/downloader.py
@@ -6,7 +6,6 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Downloader(QThread):
-    started = pyqtSignal()
     progress_changed = pyqtSignal(
         "PyQt_PyObject", "PyQt_PyObject", "PyQt_PyObject")
     finished = pyqtSignal("PyQt_PyObject")
@@ -19,7 +18,6 @@ class Downloader(QThread):
 
     def run(self):
         self.progress_changed.emit(0, 0, "Downloading")
-        self.started.emit()
 
         temp_folder = Path(get_library_folder()) / ".temp"
 

--- a/source/threads/extractor.py
+++ b/source/threads/extractor.py
@@ -7,9 +7,8 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Extractor(QThread):
-    progress_changed = pyqtSignal(
-        "PyQt_PyObject", "PyQt_PyObject", "PyQt_PyObject")
-    finished = pyqtSignal("PyQt_PyObject")
+    progress_changed = pyqtSignal(int, int)
+    finished = pyqtSignal(Path)
 
     def __init__(self, manager, source, dist):
         QThread.__init__(self)
@@ -18,7 +17,7 @@ class Extractor(QThread):
         self.dist = Path(dist)
 
     def run(self):
-        self.progress_changed.emit(0, 0, "Extracting")
+        self.progress_changed.emit(0, 0)
 
         suffixes = self.source.suffixes
 
@@ -31,8 +30,7 @@ class Extractor(QThread):
             for file in zf.infolist():
                 zf.extract(file, self.dist)
                 extracted_size += file.file_size
-                self.progress_changed.emit(
-                    extracted_size, uncompress_size, "Extracting")
+                self.progress_changed.emit(extracted_size, uncompress_size)
 
             zf.close()
             self.finished.emit(self.dist / folder)
@@ -45,8 +43,7 @@ class Extractor(QThread):
             for member in tar.getmembers():
                 tar.extract(member, path=self.dist)
                 extracted_size += member.size
-                self.progress_changed.emit(
-                    extracted_size, uncompress_size, "Extracting")
+                self.progress_changed.emit(extracted_size, uncompress_size)
 
             tar.close()
             self.finished.emit(self.dist / folder)
@@ -61,4 +58,3 @@ class Extractor(QThread):
             _check_call(["hdiutil", "unmount", "/Volumes/Blender"])
 
             self.finished.emit(dist)
-

--- a/source/threads/extractor.py
+++ b/source/threads/extractor.py
@@ -7,7 +7,6 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Extractor(QThread):
-    started = pyqtSignal()
     progress_changed = pyqtSignal(
         "PyQt_PyObject", "PyQt_PyObject", "PyQt_PyObject")
     finished = pyqtSignal("PyQt_PyObject")
@@ -20,7 +19,6 @@ class Extractor(QThread):
 
     def run(self):
         self.progress_changed.emit(0, 0, "Extracting")
-        self.started.emit()
 
         suffixes = self.source.suffixes
 

--- a/source/threads/folder_observer.py
+++ b/source/threads/folder_observer.py
@@ -5,8 +5,6 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class FolderObserver(QThread):
-    started = pyqtSignal()
-    finished = pyqtSignal()
 
     def __init__(self, parent, folder):
         QThread.__init__(self)
@@ -14,7 +12,6 @@ class FolderObserver(QThread):
         self.folder = Path(folder)
 
     def run(self):
-        self.started.emit()
         subfolders = self.get_subfolders()
 
         while self.parent:

--- a/source/threads/library_drawer.py
+++ b/source/threads/library_drawer.py
@@ -6,7 +6,7 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class LibraryDrawer(QThread):
-    build_found = pyqtSignal("PyQt_PyObject")
+    build_found = pyqtSignal(Path)
     build_released = pyqtSignal()
 
     def __init__(self, folders=["stable", "daily", "experimental", "custom"]):

--- a/source/threads/library_drawer.py
+++ b/source/threads/library_drawer.py
@@ -7,7 +7,6 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 class LibraryDrawer(QThread):
     build_found = pyqtSignal("PyQt_PyObject")
-    finished = pyqtSignal()
     build_released = pyqtSignal()
 
     def __init__(self, folders=["stable", "daily", "experimental", "custom"]):
@@ -44,7 +43,6 @@ class LibraryDrawer(QThread):
         while self.builds_count > 0:
             QThread.msleep(250)
 
-        self.finished.emit()
 
     def handle_build_released(self):
         self.builds_count = self.builds_count - 1

--- a/source/threads/observer.py
+++ b/source/threads/observer.py
@@ -2,8 +2,6 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Observer(QThread):
-    started = pyqtSignal()
-    finished = pyqtSignal()
     count_changed = pyqtSignal("PyQt_PyObject")
     append_proc = pyqtSignal("PyQt_PyObject")
 
@@ -14,7 +12,6 @@ class Observer(QThread):
         self.append_proc.connect(self.handle_append_proc)
 
     def run(self):
-        self.started.emit()
 
         while self.parent:
             for proc in self.processes:
@@ -26,7 +23,6 @@ class Observer(QThread):
                     if proc_count > 0:
                         self.count_changed.emit(proc_count)
                     else:
-                        self.finished.emit()
                         return
 
             QThread.sleep(1)

--- a/source/threads/observer.py
+++ b/source/threads/observer.py
@@ -1,9 +1,11 @@
+from subprocess import Popen
+
 from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Observer(QThread):
-    count_changed = pyqtSignal("PyQt_PyObject")
-    append_proc = pyqtSignal("PyQt_PyObject")
+    count_changed = pyqtSignal(int)
+    append_proc = pyqtSignal(Popen)
 
     def __init__(self, parent):
         QThread.__init__(self)

--- a/source/threads/register.py
+++ b/source/threads/register.py
@@ -3,15 +3,13 @@ from pathlib import Path
 from subprocess import DEVNULL, PIPE, STDOUT
 
 from modules._platform import get_platform
-from PyQt5.QtCore import QThread, pyqtSignal
+from PyQt5.QtCore import QThread
 
 if get_platform() == "Windows":
     from subprocess import CREATE_NO_WINDOW
 
 
 class Register(QThread):
-    finished = pyqtSignal("PyQt_PyObject")
-
     def __init__(self, path):
         QThread.__init__(self)
         self.path = path
@@ -26,4 +24,3 @@ class Register(QThread):
         elif platform == "Linux":
             b3d_exe = Path(self.path) / "blender"
 
-        self.finished.emit(0)

--- a/source/threads/remover.py
+++ b/source/threads/remover.py
@@ -4,7 +4,7 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Remover(QThread):
-    finished = pyqtSignal("PyQt_PyObject")
+    completed_removal = pyqtSignal(int)
 
     def __init__(self, path, parent=None):
         QThread.__init__(self)
@@ -21,9 +21,9 @@ class Remover(QThread):
 
         try:
             rmtree(self.path.as_posix())
-            self.finished.emit(0)
+            self.completed_removal.emit(0)
         except OSError:
-            self.finished.emit(1)
+            self.completed_removal.emit(1)
 
         if self.parent is not None:
             self.parent.remover_count -= 1

--- a/source/threads/remover.py
+++ b/source/threads/remover.py
@@ -4,7 +4,6 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Remover(QThread):
-    started = pyqtSignal()
     finished = pyqtSignal("PyQt_PyObject")
 
     def __init__(self, path, parent=None):
@@ -13,7 +12,6 @@ class Remover(QThread):
         self.parent = parent
 
     def run(self):
-        self.started.emit()
 
         if self.parent is not None:
             while self.parent.remover_count > 0:

--- a/source/threads/renamer.py
+++ b/source/threads/renamer.py
@@ -4,7 +4,7 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Renamer(QThread):
-    finished = pyqtSignal("PyQt_PyObject")
+    completed = pyqtSignal([Path], [])
 
     def __init__(self, src_path, dst_name, parent=None):
         QThread.__init__(self)
@@ -23,9 +23,9 @@ class Renamer(QThread):
         try:
             dst = Path(self.src_path).parent / self.dst_name
             self.src_path.rename(dst)
-            self.finished.emit(dst)
+            self.completed.emit(dst)
         except OSError:
-            self.finished.emit(None)
+            self.completed.emit()
 
         if self.parent is not None:
             self.parent.remover_count -= 1

--- a/source/threads/renamer.py
+++ b/source/threads/renamer.py
@@ -4,7 +4,6 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class Renamer(QThread):
-    started = pyqtSignal()
     finished = pyqtSignal("PyQt_PyObject")
 
     def __init__(self, src_path, dst_name, parent=None):
@@ -14,7 +13,6 @@ class Renamer(QThread):
         self.parent = parent
 
     def run(self):
-        self.started.emit()
 
         if self.parent is not None:
             while self.parent.renamer_count > 0:

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -20,7 +20,6 @@ class Scraper(QThread):
     links = pyqtSignal("PyQt_PyObject")
     new_bl_version = pyqtSignal("PyQt_PyObject")
     error = pyqtSignal()
-    finished = pyqtSignal()
 
     def __init__(self, parent, man):
         QThread.__init__(self)
@@ -50,7 +49,6 @@ class Scraper(QThread):
         if latest_tag is not None:
             self.new_bl_version.emit(self.get_latest_tag())
         self.manager.manager.clear()
-        self.finished.emit()
 
     def get_latest_tag(self):
         r = self.manager._request(

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import re
@@ -6,19 +8,22 @@ import time
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
 import lxml
 from bs4 import BeautifulSoup, SoupStrainer
 from modules._platform import get_platform, set_locale
 from modules.build_info import BuildInfo
-from modules.connection_manager import ConnectionManager
 from PyQt5.QtCore import QThread, pyqtSignal
+
+if TYPE_CHECKING:
+    from modules.connection_manager import ConnectionManager
 
 
 class Scraper(QThread):
-    links = pyqtSignal("PyQt_PyObject")
-    new_bl_version = pyqtSignal("PyQt_PyObject")
+    links = pyqtSignal(BuildInfo)
+    new_bl_version = pyqtSignal(str)
     error = pyqtSignal()
 
     def __init__(self, parent, man):
@@ -50,7 +55,7 @@ class Scraper(QThread):
             self.new_bl_version.emit(self.get_latest_tag())
         self.manager.manager.clear()
 
-    def get_latest_tag(self):
+    def get_latest_tag(self) -> str | None:
         r = self.manager._request(
             "GET", "https://github.com/Victor-IX/Blender-Launcher/releases/latest")
 

--- a/source/threads/template_installer.py
+++ b/source/threads/template_installer.py
@@ -7,12 +7,11 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class TemplateInstaller(QThread):
-    progress_changed = pyqtSignal("PyQt_PyObject", "PyQt_PyObject")
+    progress_changed = pyqtSignal(int, object)
 
 
-    def __init__(self, manager, dist):
+    def __init__(self, dist: Path):
         QThread.__init__(self)
-        self.manager = manager
         self.dist = dist
 
     def run(self):
@@ -23,10 +22,10 @@ class TemplateInstaller(QThread):
         if not template.is_dir():
             template.mkdir()
 
-        for dir in self.dist.iterdir():
-            if match(r"\d+\.\d+.*", dir.name) is not None:
+        for directory in self.dist.iterdir():
+            if match(r"\d+\.\d+.*", directory.name) is not None:
                 source = template.as_posix()
-                dist = dir.as_posix()
+                dist = directory.as_posix()
                 copytree(source, dist, dirs_exist_ok=True)
                 return
 

--- a/source/threads/template_installer.py
+++ b/source/threads/template_installer.py
@@ -7,9 +7,8 @@ from PyQt5.QtCore import QThread, pyqtSignal
 
 
 class TemplateInstaller(QThread):
-    started = pyqtSignal()
     progress_changed = pyqtSignal("PyQt_PyObject", "PyQt_PyObject")
-    finished = pyqtSignal()
+
 
     def __init__(self, manager, dist):
         QThread.__init__(self)
@@ -29,8 +28,6 @@ class TemplateInstaller(QThread):
                 source = template.as_posix()
                 dist = dir.as_posix()
                 copytree(source, dist, dirs_exist_ok=True)
-                self.finished.emit()
                 return
 
-        self.finished.emit()
         return

--- a/source/threads/template_installer.py
+++ b/source/threads/template_installer.py
@@ -15,7 +15,7 @@ class TemplateInstaller(QThread):
         self.dist = dist
 
     def run(self):
-        self.progress_changed.emit(0, "Copying Data...")
+        self.progress_changed.emit(0, 0)
         library_folder = Path(get_library_folder())
         template = library_folder / "template"
 

--- a/source/widgets/base_progress_bar_widget.py
+++ b/source/widgets/base_progress_bar_widget.py
@@ -1,18 +1,29 @@
-from PyQt5.QtCore import Qt, pyqtSignal
+from __future__ import annotations
+
+from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QProgressBar
 
 
 class BaseProgressBarWidget(QProgressBar):
-    progress_updated = pyqtSignal("PyQt_PyObject", "PyQt_PyObject")
+    progress_updated = pyqtSignal(int, int)
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
+        self.title = ""
 
         self.setAlignment(Qt.AlignCenter)
         self.setMinimum(0)
         self.set_progress(0, 0)
 
-    def set_progress(self, obtained, total, title=""):
+    def set_title(self, title: str):
+        self.title = title
+        self.setFormat(f"{self.title}: {self.last_progress[0]:.1f} of {self.last_progress[1]:.1f} MB")
+
+    @pyqtSlot(int, int)
+    def set_progress(self, obtained: int, total: int, title: str | None = None):
+        if title is not None and title != self.title:
+            self.title = title
+
         # Convert bytes to megabytes
         obtained = obtained / 1048576
         total = total / 1048576
@@ -22,7 +33,6 @@ class BaseProgressBarWidget(QProgressBar):
         self.setValue(obtained)
 
         # Repaint and call signal
-        self.repaint()
-        self.setFormat(
-            f"{title}: {obtained:.1f} of {total:.1f} MB")
+        self.setFormat(f"{self.title}: {obtained:.1f} of {total:.1f} MB")
         self.progress_updated.emit(obtained, total)
+        self.last_progress = (obtained, total)

--- a/source/widgets/base_tool_box_widget.py
+++ b/source/widgets/base_tool_box_widget.py
@@ -3,7 +3,7 @@ from PyQt5.QtWidgets import QTabWidget
 
 
 class BaseToolBoxWidget(QTabWidget):
-    tab_changed = pyqtSignal("PyQt_PyObject")
+    tab_changed = pyqtSignal(int)
 
     def __init__(self, parent=None):
         super().__init__()
@@ -12,9 +12,8 @@ class BaseToolBoxWidget(QTabWidget):
         self.list_widgets = set()
 
         self.setContentsMargins(0, 0, 0, 0)
-        self.setTabPosition(QTabWidget.West)
+        self.setTabPosition(QTabWidget.TabPosition.West)
         self.setProperty("West", True)
-
         self.currentChanged.connect(self.current_changed)
 
     def add_page_widget(self, page_widget, page_name):

--- a/source/widgets/download_widget.py
+++ b/source/widgets/download_widget.py
@@ -215,7 +215,7 @@ class DownloadWidget(BaseBuildWidget):
         new_name = f"blender-{build_info.subversion}+{build_info.branch}.{build_info.build_hash}"
 
         self.build_renamer = Renamer(self.build_dir, new_name)
-        self.build_renamer.finished.connect(self.download_finished)
+        self.build_renamer.completed.connect(self.download_finished)
         self.build_renamer.start()
 
     def download_finished(self, path):

--- a/source/widgets/download_widget.py
+++ b/source/widgets/download_widget.py
@@ -173,6 +173,7 @@ class DownloadWidget(BaseBuildWidget):
         self.build_dir = dist
 
         if get_install_template():
+            self.progressBar.set_title("Copying data...")
             self.template_installer = TemplateInstaller(self.build_dir)
             self.template_installer.progress_changed.connect(
                 self.progressBar.set_progress)

--- a/source/widgets/download_widget.py
+++ b/source/widgets/download_widget.py
@@ -1,8 +1,9 @@
 import re
 from enum import Enum
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from modules.build_info import BuildInfoReader
+from modules.build_info import BuildInfo, BuildInfoReader
 from modules.enums import MessageType
 from modules.settings import get_install_template, get_library_folder
 from PyQt5.QtCore import Qt
@@ -17,6 +18,9 @@ from widgets.build_state_widget import BuildStateWidget
 from widgets.datetime_widget import DateTimeWidget
 from widgets.elided_text_label import ElidedTextLabel
 
+if TYPE_CHECKING:
+    from windows.main_window import BlenderLauncher
+
 
 class DownloadState(Enum):
     IDLE = 1
@@ -27,10 +31,10 @@ class DownloadState(Enum):
 
 
 class DownloadWidget(BaseBuildWidget):
-    def __init__(self, parent, list_widget, item, build_info,
+    def __init__(self, parent: "BlenderLauncher", list_widget, item, build_info,
                  show_new=False):
-        super(DownloadWidget, self).__init__(parent=parent)
-        self.parent = parent
+        super().__init__(parent=parent)
+        self.parent: "BlenderLauncher" = parent
         self.list_widget = list_widget
         self.item = item
         self.build_info = build_info
@@ -87,8 +91,7 @@ class DownloadWidget(BaseBuildWidget):
         self.branchLabel = ElidedTextLabel(branch_name)
         self.commitTimeLabel = DateTimeWidget(
             self.build_info.commit_time, self.build_info.build_hash)
-        self.build_state_widget = BuildStateWidget(
-            self.parent, self.list_widget)
+        self.build_state_widget = BuildStateWidget(parent, self.list_widget)
 
         self.build_info_hl.addWidget(self.subversionLabel)
         self.build_info_hl.addWidget(self.branchLabel, stretch=1)
@@ -138,23 +141,21 @@ class DownloadWidget(BaseBuildWidget):
             self.show_new = False
 
         self.state = DownloadState.DOWNLOADING
+        self.progressBar.set_title("Downloading")
         self.downloader = Downloader(self.parent.manager, self.build_info.link)
         self.downloader.started.connect(self.download_started)
         self.downloader.progress_changed.connect(self.progressBar.set_progress)
         self.downloader.finished.connect(self.init_extractor)
-
-        self.progress_start = 0
-        self.progress_end = 0.5
-
         self.downloader.start()
 
     def init_extractor(self, source):
         self.state = DownloadState.EXTRACTING
+        self.progressBar.set_title("Extracting")
+
         self.cancelButton.setEnabled(False)
         library_folder = Path(get_library_folder())
 
-        if (self.build_info.branch == "stable") or \
-                (self.build_info.branch == "lts"):
+        if self.build_info.branch in ("stable", "lts"):
             dist = library_folder / "stable"
         elif self.build_info.branch == "daily":
             dist = library_folder / "daily"
@@ -172,12 +173,10 @@ class DownloadWidget(BaseBuildWidget):
         self.build_dir = dist
 
         if get_install_template():
-            self.template_installer = TemplateInstaller(
-                self.parent.manager, self.build_dir)
+            self.template_installer = TemplateInstaller(self.build_dir)
             self.template_installer.progress_changed.connect(
                 self.progressBar.set_progress)
-            self.template_installer.finished.connect(
-                lambda: self.download_get_info())
+            self.template_installer.finished.connect(self.download_get_info)
             self.template_installer.start()
         else:
             self.download_get_info()
@@ -207,10 +206,10 @@ class DownloadWidget(BaseBuildWidget):
 
         self.build_info_reader = BuildInfoReader(
             self.build_dir, archive_name=archive_name)
-        self.build_info_reader.finished.connect(self.download_rename)
+        self.build_info_reader.read.connect(self.download_rename)
         self.build_info_reader.start()
 
-    def download_rename(self, build_info):
+    def download_rename(self, build_info: BuildInfo):
         self.state = DownloadState.RENAMING
         new_name = f"blender-{build_info.subversion}+{build_info.branch}.{build_info.build_hash}"
 

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -17,7 +17,7 @@ from modules.settings import (
 )
 from modules.shortcut import create_shortcut
 from PyQt5 import QtCore
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, pyqtSlot
 from PyQt5.QtWidgets import QAction, QApplication, QHBoxLayout, QLabel
 from threads.observer import Observer
 from threads.register import Register
@@ -61,8 +61,9 @@ class LibraryWidget(BaseBuildWidget):
         if self.parent_widget is None:
             self.setEnabled(False)
             self.infoLabel = QLabel("Loading build information...")
+            self.infoLabel.setWordWrap(True)
 
-            self.launchButton = LeftIconButtonWidget("Launch")
+            self.launchButton = LeftIconButtonWidget("")
             self.launchButton.setFixedWidth(85)
             self.launchButton.setProperty("CancelButton", True)
 
@@ -70,24 +71,25 @@ class LibraryWidget(BaseBuildWidget):
             self.layout.addWidget(self.infoLabel, stretch=1)
 
             self.build_info_reader = BuildInfoReader(link)
-            self.build_info_reader.finished.connect(self.draw)
+            self.build_info_reader.read.connect(self.draw)
+            self.build_info_reader.error.connect(self.trigger_damaged)
             self.build_info_reader.start()
         else:
             self.draw(self.parent_widget.build_info)
+
+    @pyqtSlot()
+    def trigger_damaged(self):
+        self.infoLabel.setText(f"Build *{Path(self.link).name}* is damaged!")
+        self.launchButton._setText("Delete")
+        self.launchButton.clicked.connect(self.ask_remove_from_drive)
+        self.setEnabled(True)
+        self.is_damaged = True
+
 
     def draw(self, build_info):
         if self.parent_widget is None:
             if self.parent.library_drawer is not None:
                 self.parent.library_drawer.build_released.emit()
-
-            if build_info is None:
-                self.infoLabel.setText(
-                    f"Build *{Path(self.link).name}* is damaged!")
-                self.launchButton.setText("Delete")
-                self.launchButton.clicked.connect(self.ask_remove_from_drive)
-                self.setEnabled(True)
-                self.is_damaged = True
-                return
 
             for i in reversed(range(self.layout.count())):
                 self.layout.itemAt(i).widget().setParent(None)
@@ -303,8 +305,7 @@ class LibraryWidget(BaseBuildWidget):
         self.launchButton.setEnabled(False)
         self.deleteAction.setEnabled(False)
         self.installTemplateAction.setEnabled(False)
-        self.tempalte_installer = TemplateInstaller(
-            self.parent.manager, self.link)
+        self.tempalte_installer = TemplateInstaller(self.link)
         self.tempalte_installer.finished.connect(
             self.install_template_finished)
         self.tempalte_installer.start()
@@ -458,7 +459,7 @@ class LibraryWidget(BaseBuildWidget):
         path = Path(get_library_folder()) / self.link
         self.remover = Remover(path, self.parent)
         self.remover.started.connect(self.remover_started)
-        self.remover.finished.connect(self.remover_finished)
+        self.remover.completed_removal.connect(self.remover_completed)
         self.remover.start()
 
     # TODO Clear icon if build in quick launch
@@ -470,9 +471,9 @@ class LibraryWidget(BaseBuildWidget):
         if self.child_widget is not None:
             self.child_widget.remover_started()
 
-    def remover_finished(self, code):
+    def remover_completed(self, code):
         if self.child_widget is not None:
-            self.child_widget.remover_finished(code)
+            self.child_widget.remover_completed(code)
 
         if code == 0:
             self.list_widget.remove_item(self.item)


### PR DESCRIPTION
many thread classes override the QThread signals `started`, and `finished`, which, as you  can guess, emits when a thread starts or finishes. Many of these new signals are used identically to the base signals aswell! 

In this pr those have been deleted. as for the ones which extend the capability, such as returning a BuildInfo or something, they were given a more meaningful name

All remaining signals with outputs were also given more specific type data, as before they used the blanket "PyQt_PyObject" previously 

other small changes:
- rework BaseProgressBarWidget.set_progress
- remove TemplateInstaller dependancy on ConnectionManager

This is a draft because I'm not entirely sure every single signal signature matches properly, such as the TemplateInstaller. I'm not entirely sure how to even access that