### PR TITLE
fix favorite duplication

### DIFF
--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -530,8 +530,8 @@ class LibraryWidget(BaseBuildWidget):
         widget = LibraryWidget(self.parent, item, self.link,
                                self.parent.UserFavoritesListWidget,
                                parent_widget=self)
-
-        self.parent.UserFavoritesListWidget.insert_item(item, widget)
+        if not self.parent.UserFavoritesListWidget.contains_build_info(self.build_info):
+            self.parent.UserFavoritesListWidget.insert_item(item, widget)
         self.child_widget = widget
 
         self.removeFromFavoritesAction.setVisible(True)


### PR DESCRIPTION
If a list widget is somehow replaced, like custom user builds, the builds that are marked as favorites are duplicated. this checks if the build_info exists in the favorites list before attempting to add the item to the list.