### PR TITLE
Github action for automated Ubuntu builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Build
         run: |
           python3 -m venv .venv
           source ./.venv/bin/activate
           pip install -e ./
           sh ./build_linux.sh
-          zip Blender_Launcher_${GITHUB_REF##*/}_Linux_x64.zip "./dist/release/Blender Launcher"
+          echo "Zipping to Blender_Launcher_${{ env.RELEASE_VERSION }}_Linux_x64.zip"
+          zip Blender_Launcher_${{ env.RELEASE_VERSION }}_Linux_x64.zip "./dist/release/Blender Launcher"
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ./Blender_Launcher_${GITHUB_REF##*/}_Linux_x64.zip
+          files: ./Blender_Launcher_${{ env.RELEASE_VERSION }}_Linux_x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build
         run: |
           python3 -m venv .venv
-          source ./my_venv/bin/activate
+          source ./.venv/bin/activate
           pip install -e
           sh ./build_linux.sh
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Build
-        uses: actions/setup-python@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5.0.0
         with:
-            python-version: '3.9'
+          python-version: '3.9'
+      - name: Build
         run: |
           python3 -m venv .venv
           source ./.venv/bin/activate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Main
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: echo ${{ github.sha }} > Release.txt
+      - name: Test
+        run: cat Release.txt
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Release.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,13 @@ jobs:
           source ./.venv/bin/activate
           pip install -e ./
           sh ./build_linux.sh
-          echo "Zipping to Blender_Launcher_${{ env.RELEASE_VERSION }}_Linux_x64.zip"
-          zip Blender_Launcher_${{ env.RELEASE_VERSION }}_Linux_x64.zip "./dist/release/Blender Launcher"
+      - name: Zipping
+        run: |
+          echo "Zipping to Blender_Launcher_${{ env.RELEASE_VERSION }}_Ubuntu_x64.zip"
+          cd ./dist/release/
+          zip Blender_Launcher_${{ env.RELEASE_VERSION }}_Ubuntu_x64.zip "./dist/release/Blender Launcher"
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ./Blender_Launcher_${{ env.RELEASE_VERSION }}_Linux_x64.zip
+          files: ./dist/release/Blender_Launcher_${{ env.RELEASE_VERSION }}_Ubuntu_x64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        run: echo ${{ github.sha }} > Release.txt
-      - name: Test
-        run: cat Release.txt
+        run:
+          python3 -m venv-venv
+          source ./my_venv/bin/activate
+          pip install -e
+          sh ./build_linux.sh
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: Release.txt
+          files: "./dist/release/Blender Launcher"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "Zipping to Blender_Launcher_${{ env.RELEASE_VERSION }}_Ubuntu_x64.zip"
           cd ./dist/release/
-          zip Blender_Launcher_${{ env.RELEASE_VERSION }}_Ubuntu_x64.zip "./dist/release/Blender Launcher"
+          zip Blender_Launcher_${{ env.RELEASE_VERSION }}_Ubuntu_x64.zip "./Blender Launcher"
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build
         run:
-          python3 -m venv-venv
+          python3 -m venv .venv
           source ./my_venv/bin/activate
           pip install -e
           sh ./build_linux.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source ./.venv/bin/activate
-          pip install -e
+          pip install -e ./
           sh ./build_linux.sh
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Build
+        uses: actions/setup-python@v4
+        with:
+            python-version: '3.9'
         run: |
           python3 -m venv .venv
           source ./.venv/bin/activate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        run:
+        run: |
           python3 -m venv .venv
           source ./my_venv/bin/activate
           pip install -e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,9 @@ jobs:
           source ./.venv/bin/activate
           pip install -e ./
           sh ./build_linux.sh
+          zip Blender_Launcher_${GITHUB_REF##*/}_Linux_x64.zip "./dist/release/Blender Launcher"
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: "./dist/release/Blender Launcher"
+          files: ./Blender_Launcher_${GITHUB_REF##*/}_Linux_x64.zip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,6 @@ target-version = "py39"
 
 [tool.isort]
 profile = "black"
+
+[tool.setuptools]
+py-modules = ["source"]


### PR DESCRIPTION
To fix #15 on Ubuntu systems, I made an automated github action that automatically build the app on version release.

For example: https://github.com/RustyNova016/Blender-Launcher-V2/releases/tag/v1.16.1