### PR TITLE
Resolve stdout errors, file_dialog_window recursion, stable downloads and right click menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ Blender Launcher.ini
 log_file.txt
 Blender-Launcher.code-workspace
 .pdm-python
+__pypackages__

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ MANIFEST
 *.manifest
 *.spec
 
+# PDM Stuff
+__pypackages__
+.pdm-python
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -105,10 +109,8 @@ docs/site
 
 # VS Code
 .vscode
+Blender-Launcher.code-workspace
 
 # Application related settings
 Blender Launcher.ini
 log_file.txt
-Blender-Launcher.code-workspace
-.pdm-python
-__pypackages__

--- a/source/modules/connection_manager.py
+++ b/source/modules/connection_manager.py
@@ -39,7 +39,7 @@ class ConnectionManager(QObject):
 
         # Basic Headers
         self._headers = {
-            "user-agent": f"Blender Launcher/{self.version} ({get_platform_full()})"}
+            "user-agent": f"BLV2/{self.version} ({get_platform_full()})"}
 
         # Get custom certificates file path
         if is_frozen() is True:

--- a/source/widgets/base_menu_widget.py
+++ b/source/widgets/base_menu_widget.py
@@ -1,6 +1,6 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QCursor
-from PyQt5.QtWidgets import QDesktopWidget, QMenu
+from PyQt5.QtWidgets import QApplication, QMenu
 
 
 class BaseMenuWidget(QMenu):
@@ -10,7 +10,7 @@ class BaseMenuWidget(QMenu):
         super().__init__(title=title)
         self.setWindowFlags(self.windowFlags() | Qt.NoDropShadowWindowHint)
         self.action_height = BaseMenuWidget.action_height
-        self.screen_size = QDesktopWidget().screenGeometry()
+        self.screen_size = QApplication.desktop().screenGeometry(self)
         self.setToolTipsVisible(True)
 
     def trigger(self):
@@ -25,7 +25,7 @@ class BaseMenuWidget(QMenu):
         reverse = False
 
         cursor = QCursor.pos()
-        cursor.setX(cursor.x() - self.action_height * 0.5)
+        cursor.setX(cursor.x() - round(self.action_height * 0.5))
 
         if cursor.y() > (self.screen_size.height() - menu_height):
             reverse = True
@@ -34,7 +34,7 @@ class BaseMenuWidget(QMenu):
             actions.reverse()
             cursor.setY(cursor.y() - actions_count * self.action_height + 15)
         else:
-            cursor.setY(cursor.y() - self.action_height * 0.5)
+            cursor.setY(cursor.y() - round(self.action_height * 0.5))
 
         i = 0
 

--- a/source/widgets/base_menu_widget.py
+++ b/source/widgets/base_menu_widget.py
@@ -8,9 +8,11 @@ class BaseMenuWidget(QMenu):
 
     def __init__(self, title=""):
         super().__init__(title=title)
-        self.setWindowFlags(self.windowFlags() | Qt.NoDropShadowWindowHint)
+        self.setWindowFlags(self.windowFlags())
         self.action_height = BaseMenuWidget.action_height
-        self.screen_size = QApplication.desktop().screenGeometry(self)
+        desktop = QApplication.desktop()
+        assert desktop is not None
+        self.screen_size = desktop.screenGeometry(self)
         self.setToolTipsVisible(True)
 
     def trigger(self):

--- a/source/widgets/base_progress_bar_widget.py
+++ b/source/widgets/base_progress_bar_widget.py
@@ -18,8 +18,8 @@ class BaseProgressBarWidget(QProgressBar):
         total = total / 1048576
 
         # Update appearance
-        self.setMaximum(total)
-        self.setValue(obtained)
+        self.setMaximum(int(round(total)))
+        self.setValue(int(round(obtained)))
 
         # Repaint and call signal
         self.repaint()

--- a/source/widgets/download_widget.py
+++ b/source/widgets/download_widget.py
@@ -77,9 +77,8 @@ class DownloadWidget(BaseBuildWidget):
         elif self.build_info.branch == "daily":
             branch_name = self.build_info.subversion.split(" ", 1)[1].title()
         else:
-            branch_name = self.build_info.subversion.split(" ", 1)[1]
-            # branch_name = re.sub(
-            #     r"(\-|\_)", " ", self.build_info.branch).title()
+            branch_name = re.sub(
+                r"(\-|\_)", " ", self.build_info.branch).title()
 
         self.subversionLabel = QLabel(
             self.build_info.subversion.split(" ", 1)[0])

--- a/source/widgets/settings_window/general_tab.py
+++ b/source/widgets/settings_window/general_tab.py
@@ -80,7 +80,7 @@ class GeneralTabWidget(SettingsFormWidget):
         self.NewBuildsCheckFrequency.setMaximum(24 * 60)
         self.NewBuildsCheckFrequency.setMinimum(120)
         self.NewBuildsCheckFrequency.setValue(
-            get_new_builds_check_frequency() / 60)
+            round(get_new_builds_check_frequency() / 60))
         self.NewBuildsCheckFrequency.editingFinished.connect(
             self.new_builds_check_frequency_changed)
 

--- a/source/widgets/settings_window/general_tab.py
+++ b/source/widgets/settings_window/general_tab.py
@@ -116,7 +116,7 @@ class GeneralTabWidget(SettingsFormWidget):
 
     def set_library_folder(self):
         library_folder = str(get_library_folder())
-        new_library_folder = FileDialogWindow().getExistingDirectory(
+        new_library_folder = FileDialogWindow().get_directory(
             self, "Select Library Folder", library_folder)
 
         if new_library_folder and (library_folder != new_library_folder):

--- a/source/windows/base_window.py
+++ b/source/windows/base_window.py
@@ -79,14 +79,14 @@ class BaseWindow(QWidget):
                 parent.close_signal.connect(self.hide)
 
             if self.parent.isVisible():
-                x = parent.x() + (parent.width() - self.width()) * 0.5
-                y = parent.y() + (parent.height() - self.height()) * 0.5
+                x = parent.x() + (parent.width() - round(self.width()) * 0.5)
+                y = parent.y() + (parent.height() - round(self.height()) * 0.5)
             else:
                 size = parent.app.screens()[0].size()
-                x = (size.width() - self.width()) * 0.5
-                y = (size.height() - self.height()) * 0.5
+                x = (size.width() - round(self.width()) * 0.5)
+                y = (size.height() - round(self.height()) * 0.5)
 
-            self.move(int(round(x)), int(round(y)))
+            self.move(x, y)
             event.accept()
 
     def _destroyed(self):

--- a/source/windows/base_window.py
+++ b/source/windows/base_window.py
@@ -86,7 +86,7 @@ class BaseWindow(QWidget):
                 x = (size.width() - self.width()) * 0.5
                 y = (size.height() - self.height()) * 0.5
 
-            self.move(x, y)
+            self.move(int(round(x)), int(round(y)))
             event.accept()
 
     def _destroyed(self):

--- a/source/windows/file_dialog_window.py
+++ b/source/windows/file_dialog_window.py
@@ -5,11 +5,11 @@ class FileDialogWindow(QFileDialog):
     def __init__(self):
         super().__init__()
 
-    def getExistingDirectory(self, parent, title, directory):
+    def get_directory(self, parent, title, directory):
         options = (
             QFileDialog.DontUseNativeDialog |
             QFileDialog.ShowDirsOnly |
             QFileDialog.HideNameFilterDetails |
             QFileDialog.DontUseCustomDirectoryIcons)
-        return super().getExistingDirectory(
+        return QFileDialog.getExistingDirectory(
             parent, title, directory, options)

--- a/source/windows/file_dialog_window.py
+++ b/source/windows/file_dialog_window.py
@@ -11,5 +11,5 @@ class FileDialogWindow(QFileDialog):
             QFileDialog.ShowDirsOnly |
             QFileDialog.HideNameFilterDetails |
             QFileDialog.DontUseCustomDirectoryIcons)
-        return self.getExistingDirectory(
+        return super().getExistingDirectory(
             parent, title, directory, options)

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -162,7 +162,7 @@ class BlenderLauncher(QMainWindow, BaseWindow, Ui_MainWindow):
 
     def set_library_folder(self):
         library_folder = get_cwd().as_posix()
-        new_library_folder = FileDialogWindow().getExistingDirectory(
+        new_library_folder = FileDialogWindow().get_directory(
             self, "Select Library Folder", library_folder)
 
         if (new_library_folder):


### PR DESCRIPTION
- This resolves errors when rendering the main window on a new system when asked where to store files.
- May require more review from QT expert: prevented some TypeErrors which cluttered up the stdout and broke right click menu (int expected, got float), by rounding and parsing to int.
- Resolved blocking of user agent by changing the name part to BLV2