### PR TITLE
Preference manager

### DIFF
--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -9,7 +9,8 @@ from PyQt5.QtCore import QSettings
 tabs = {
     "Library": 0,
     "Downloads": 1,
-    "User": 2
+    "User": 2,
+    "Preferences": 3
 }
 
 library_pages = {
@@ -195,6 +196,11 @@ def get_default_tab():
 def set_default_tab(tab):
     get_settings().setValue("default_tab", tabs[tab])
 
+def get_default_preferences_tab():
+    return get_settings().value("default_preferences_tab", defaultValue=0, type=int)
+
+def set_default_preferences_tab(tab):
+    get_settings().setValue("default_preferences_tab", tabs[tab])
 
 def get_list_sorting_type(list_name):
     return get_settings().value(f"Internal/{list_name}_sorting_type", defaultValue=1, type=int)

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -20,6 +20,7 @@ from modules.settings import (
     create_library_folders,
     get_default_downloads_page,
     get_default_library_page,
+    get_default_preferences_tab,
     get_default_tab,
     get_enable_download_notifications,
     get_enable_new_builds_notifications,
@@ -131,7 +132,6 @@ class BlenderLauncher(BaseWindow):
         if self.platform == "macOS":
             self.app.aboutToQuit.connect(self._aboutToQuit)
 
-
         # Setup window
         self.setWindowTitle("Blender Launcher")
         self.app.setWindowIcon(self.icons.taskbar)
@@ -145,10 +145,13 @@ class BlenderLauncher(BaseWindow):
                 self.draw(True)
             else:
                 self.dlg = DialogWindow(
-                    parent=self, title="Warning",
+                    parent=self,
+                    title="Warning",
                     text="Passed path is not a valid folder or<br>\
                     it doesn't have write permissions!",
-                    accept_text="Quit", cancel_text=None)
+                    accept_text="Quit",
+                    cancel_text=None,
+                )
                 self.dlg.accepted.connect(lambda: self.app.quit())
 
             return
@@ -156,29 +159,34 @@ class BlenderLauncher(BaseWindow):
         # Check library folder
         if is_library_folder_valid() is False:
             self.dlg = DialogWindow(
-                parent=self, title="Setup",
+                parent=self,
+                title="Setup",
                 text="First, choose where Blender<br>builds will be stored",
-                accept_text="Continue", cancel_text=None, icon=DialogIcon.INFO)
+                accept_text="Continue",
+                cancel_text=None,
+                icon=DialogIcon.INFO,
+            )
             self.dlg.accepted.connect(self.set_library_folder)
         else:
             create_library_folders(get_library_folder())
             self.draw()
 
-
     def set_library_folder(self):
         library_folder = get_cwd().as_posix()
-        new_library_folder = FileDialogWindow().get_directory(
-            self, "Select Library Folder", library_folder)
+        new_library_folder = FileDialogWindow().get_directory(self, "Select Library Folder", library_folder)
 
-        if (new_library_folder):
+        if new_library_folder:
             if set_library_folder(new_library_folder) is True:
                 self.draw(True)
             else:
                 self.dlg = DialogWindow(
-                    parent=self, title="Warning",
+                    parent=self,
+                    title="Warning",
                     text="Selected folder is not valid or<br>\
                     doesn't have write permissions!",
-                    accept_text="Retry", cancel_text=None)
+                    accept_text="Retry",
+                    cancel_text=None,
+                )
                 self.dlg.accepted.connect(self.set_library_folder)
         else:
             self.app.quit()
@@ -195,11 +203,13 @@ class BlenderLauncher(BaseWindow):
         self.SettingsButton.setProperty("HeaderButton", True)
         self.DocsButton.setProperty("HeaderButton", True)
 
-
         self.header = WindowHeader(
             self,
             "Blender Launcher",
-            (self.SettingsButton, self.DocsButton,),
+            (
+                self.SettingsButton,
+                self.DocsButton,
+            ),
         )
         self.header.close_signal.connect(self.attempt_close)
         self.header.minimize_signal.connect(self.showMinimized)
@@ -228,77 +238,86 @@ class BlenderLauncher(BaseWindow):
         self.UserTab.setLayout(self.UserTabLayout)
         self.TabWidget.addTab(self.UserTab, "User")
 
+        self.PreferencesTab = QWidget()
+        self.PreferencesTabLayout = QVBoxLayout()
+        self.PreferencesTabLayout.setContentsMargins(0, 0, 0, 0)
+        self.PreferencesTab.setLayout(self.PreferencesTabLayout)
+        self.TabWidget.addTab(self.PreferencesTab, "Preferences")
+
         self.LibraryToolBox = BaseToolBoxWidget(self)
         self.DownloadsToolBox = BaseToolBoxWidget(self)
         self.UserToolBox = BaseToolBoxWidget(self)
+        self.PreferencesToolBox = BaseToolBoxWidget(self)
 
-        self.toggle_sync_library_and_downloads_pages(
-            get_sync_library_and_downloads_pages())
+        self.toggle_sync_library_and_downloads_pages(get_sync_library_and_downloads_pages())
 
         self.LibraryTabLayout.addWidget(self.LibraryToolBox)
         self.DownloadsTabLayout.addWidget(self.DownloadsToolBox)
         self.UserTabLayout.addWidget(self.UserToolBox)
+        self.PreferencesTabLayout.addWidget(self.PreferencesToolBox)
 
         self.LibraryStablePageWidget = BasePageWidget(
             parent=self,
             page_name="LibraryStableListWidget",
             time_label="Commit Time",
             info_text="Nothing to show yet",
-            extended_selection=True)
-        self.LibraryStableListWidget = \
-            self.LibraryToolBox.add_page_widget(self.LibraryStablePageWidget, "Stable")
+            extended_selection=True,
+        )
+        self.LibraryStableListWidget = self.LibraryToolBox.add_page_widget(self.LibraryStablePageWidget, "Stable")
 
         self.LibraryDailyPageWidget = BasePageWidget(
             parent=self,
             page_name="LibraryDailyListWidget",
             time_label="Commit Time",
             info_text="Nothing to show yet",
-            extended_selection=True)
-        self.LibraryDailyListWidget = \
-            self.LibraryToolBox.add_page_widget(self.LibraryDailyPageWidget, "Daily")
+            extended_selection=True,
+        )
+        self.LibraryDailyListWidget = self.LibraryToolBox.add_page_widget(self.LibraryDailyPageWidget, "Daily")
 
         self.LibraryExperimentalPageWidget = BasePageWidget(
             parent=self,
             page_name="LibraryExperimentalListWidget",
             time_label="Commit Time",
             info_text="Nothing to show yet",
-            extended_selection=True)
-        self.LibraryExperimentalListWidget = \
-            self.LibraryToolBox.add_page_widget(self.LibraryExperimentalPageWidget, "Experimental")
+            extended_selection=True,
+        )
+        self.LibraryExperimentalListWidget = self.LibraryToolBox.add_page_widget(
+            self.LibraryExperimentalPageWidget, "Experimental"
+        )
 
         self.DownloadsStablePageWidget = BasePageWidget(
             parent=self,
             page_name="DownloadsStableListWidget",
             time_label="Upload Time",
-            info_text="No new builds available")
-        self.DownloadsStableListWidget = \
-            self.DownloadsToolBox.add_page_widget(self.DownloadsStablePageWidget, "Stable")
+            info_text="No new builds available",
+        )
+        self.DownloadsStableListWidget = self.DownloadsToolBox.add_page_widget(self.DownloadsStablePageWidget, "Stable")
 
         self.DownloadsDailyPageWidget = BasePageWidget(
             parent=self,
             page_name="DownloadsDailyListWidget",
             time_label="Upload Time",
-            info_text="No new builds available")
-        self.DownloadsDailyListWidget = \
-            self.DownloadsToolBox.add_page_widget(self.DownloadsDailyPageWidget, "Daily")
+            info_text="No new builds available",
+        )
+        self.DownloadsDailyListWidget = self.DownloadsToolBox.add_page_widget(self.DownloadsDailyPageWidget, "Daily")
 
         self.DownloadsExperimentalPageWidget = BasePageWidget(
             parent=self,
             page_name="DownloadsExperimentalListWidget",
             time_label="Upload Time",
-            info_text="No new builds available")
-        self.DownloadsExperimentalListWidget = \
-            self.DownloadsToolBox.add_page_widget(
-                self.DownloadsExperimentalPageWidget, "Experimental")
+            info_text="No new builds available",
+        )
+        self.DownloadsExperimentalListWidget = self.DownloadsToolBox.add_page_widget(
+            self.DownloadsExperimentalPageWidget, "Experimental"
+        )
 
         self.UserFavoritesListWidget = BasePageWidget(
             parent=self,
             page_name="UserFavoritesListWidget",
             time_label="Commit Time",
-            info_text="Nothing to show yet")
-        self.UserFavoritesListWidget = \
-            self.UserToolBox.add_page_widget(
-                self.UserFavoritesListWidget, "Favorites")
+            info_text="Nothing to show yet"
+        )
+        self.UserFavoritesListWidget = self.UserToolBox.add_page_widget(self.UserFavoritesListWidget, "Favorites")
 
         self.UserCustomPageWidget = BasePageWidget(
             parent=self,
@@ -306,13 +325,24 @@ class BlenderLauncher(BaseWindow):
             time_label="Commit Time",
             info_text="Nothing to show yet",
             show_reload=True,
-            extended_selection=True)
-        self.UserCustomListWidget = \
-            self.UserToolBox.add_page_widget(self.UserCustomPageWidget, "Custom")
+            extended_selection=True,
+        )
+        self.UserCustomListWidget = self.UserToolBox.add_page_widget(self.UserCustomPageWidget, "Custom")
+
+        self.PreferancesPageWidget = BasePageWidget(
+            parent=self,
+            page_name="PreferancesPageWidget",
+            time_label="Commit Time",
+            info_text="Nothing to show yet",
+            show_reload=True,
+            extended_selection=True,
+        )
+        self.PreferancesListWidget = self.PreferencesToolBox.add_page_widget(self.PreferancesPageWidget, "Versions")
 
         self.TabWidget.setCurrentIndex(get_default_tab())
         self.LibraryToolBox.setCurrentIndex(get_default_library_page())
         self.DownloadsToolBox.setCurrentIndex(get_default_downloads_page())
+        self.PreferencesToolBox.setCurrentIndex(get_default_preferences_tab())
 
         # Status bar
         self.status_bar = QStatusBar(self)
@@ -329,8 +359,8 @@ class BlenderLauncher(BaseWindow):
         self.statusbarVersion = QPushButton(self.version)
         self.statusbarVersion.clicked.connect(self.show_changelog)
         self.statusbarVersion.setToolTip(
-            "The version of Blender Launcher that is currently run. "
-            "Press to check changelog.")
+            "The version of Blender Launcher that is currently run. " "Press to check changelog."
+        )
         self.status_bar.addPermanentWidget(self.ForceCheckNewBuilds)
         self.status_bar.addPermanentWidget(QLabel("│"))
         self.status_bar.addPermanentWidget(self.statusbarLabel)
@@ -355,13 +385,15 @@ class BlenderLauncher(BaseWindow):
 
         self.tray_menu = BaseMenuWidget()
         self.tray_menu.setFont(self.font_10)
-        self.tray_menu.addActions([
-            quick_launch_action,
-            show_favorites_action,
-            show_action,
-            hide_action,
-            quit_action,
-        ])
+        self.tray_menu.addActions(
+            [
+                quick_launch_action,
+                show_favorites_action,
+                show_action,
+                hide_action,
+                quit_action,
+            ]
+        )
 
         # Setup tray icon
         self.tray_icon = QSystemTrayIcon(self)
@@ -411,13 +443,15 @@ class BlenderLauncher(BaseWindow):
                 key_seq = key_seq.replace(key, "<" + key + ">")
 
         try:
-            self.hk_listener = keyboard.GlobalHotKeys({
-                key_seq: self.on_activate_quick_launch})
+            self.hk_listener = keyboard.GlobalHotKeys({key_seq: self.on_activate_quick_launch})
         except Exception:
             self.dlg = DialogWindow(
-                parent=self, title="Warning",
+                parent=self,
+                title="Warning",
                 text="Global hotkey sequence was not recognized!<br>Try to use another combination of keys",
-                accept_text="OK", cancel_text=None)
+                accept_text="OK",
+                cancel_text=None,
+            )
             return
 
         self.hk_listener.start()
@@ -432,10 +466,8 @@ class BlenderLauncher(BaseWindow):
 
     def toggle_sync_library_and_downloads_pages(self, is_sync):
         if is_sync:
-            self.LibraryToolBox.tab_changed.connect(
-                lambda i: self.DownloadsToolBox.setCurrentIndex(i))
-            self.DownloadsToolBox.tab_changed.connect(
-                lambda i: self.LibraryToolBox.setCurrentIndex(i))
+            self.LibraryToolBox.tab_changed.connect(lambda i: self.DownloadsToolBox.setCurrentIndex(i))
+            self.DownloadsToolBox.tab_changed.connect(lambda i: self.LibraryToolBox.setCurrentIndex(i))
         else:
             if self.isSignalConnected(self.LibraryToolBox, "tab_changed()"):
                 self.LibraryToolBox.tab_changed.disconnect()
@@ -466,10 +498,13 @@ class BlenderLauncher(BaseWindow):
     def show_update_window(self):
         if not self.is_downloading_idle():
             self.dlg = DialogWindow(
-                parent=self, title="Warning",
+                parent=self,
+                title="Warning",
                 text="In order to update Blender Launcher<br> \
                         complete all active downloads!",
-                accept_text="OK", cancel_text=None)
+                accept_text="OK",
+                cancel_text=None,
+            )
 
             return
 
@@ -486,8 +521,7 @@ class BlenderLauncher(BaseWindow):
         source = cwd / bl_exe
         dist = cwd / blu_exe
 
-        with open(source.as_posix(), "rb") as f1, \
-                open(dist.as_posix(), "wb") as f2:
+        with open(source.as_posix(), "rb") as f1, open(dist.as_posix(), "wb") as f2:
             copyfileobj(f1, f2)
 
         # Run 'Blender Launcher Updater.exe' with '-update' flag
@@ -522,24 +556,21 @@ class BlenderLauncher(BaseWindow):
             self.thumbnail_toolbar = QWinThumbnailToolBar(self)
             self.thumbnail_toolbar.setWindow(self.windowHandle())
 
-            self.toolbar_quick_launch_btn = QWinThumbnailToolButton(
-                self.thumbnail_toolbar)
+            self.toolbar_quick_launch_btn = QWinThumbnailToolButton(self.thumbnail_toolbar)
             self.toolbar_quick_launch_btn.setIcon(self.icons.quick_launch)
             self.toolbar_quick_launch_btn.setToolTip("Quick Launch")
             self.toolbar_quick_launch_btn.clicked.connect(self.quick_launch)
             self.thumbnail_toolbar.addButton(self.toolbar_quick_launch_btn)
 
-            self.toolbar_quit_btn = QWinThumbnailToolButton(
-                self.thumbnail_toolbar)
+            self.toolbar_quit_btn = QWinThumbnailToolButton(self.thumbnail_toolbar)
             self.toolbar_quit_btn.setIcon(self.icons.close)
             self.toolbar_quit_btn.setToolTip("Quit")
             self.toolbar_quit_btn.clicked.connect(self.quit_)
             self.thumbnail_toolbar.addButton(self.toolbar_quit_btn)
 
     def show_message(self, message, value=None, message_type=None):
-        if (
-            (message_type == MessageType.DOWNLOADFINISHED and not get_enable_download_notifications())
-            or (message_type == MessageType.NEWBUILDS and not get_enable_new_builds_notifications())
+        if (message_type == MessageType.DOWNLOADFINISHED and not get_enable_download_notifications()) or (
+            message_type == MessageType.NEWBUILDS and not get_enable_new_builds_notifications()
         ):
             return
 
@@ -551,7 +582,6 @@ class BlenderLauncher(BaseWindow):
     def message_from_error(self, err: Exception):
         if get_make_error_popup():
             self.show_message(f"An error has occurred: {err}\nSee the logs for more details.", MessageType.ERROR)
-
 
     def show_favorites(self):
         self.TabWidget.setCurrentWidget(self.UserTab)
@@ -567,9 +597,13 @@ class BlenderLauncher(BaseWindow):
 
     def quick_launch_fail(self):
         self.dlg = DialogWindow(
-            parent=self, text="Add build to Quick Launch via<br>\
+            parent=self,
+            text="Add build to Quick Launch via<br>\
                         context menu to run it from tray",
-            accept_text="OK", cancel_text=None, icon=DialogIcon.INFO)
+            accept_text="OK",
+            cancel_text=None,
+            icon=DialogIcon.INFO,
+        )
 
     def tray_icon_activated(self, reason):
         if reason == QSystemTrayIcon.ActivationReason.Trigger:
@@ -587,13 +621,16 @@ class BlenderLauncher(BaseWindow):
         busy = self.action_queue.get_busy_threads()
         if any(busy):
             self.dlg = DialogWindow(
-                parent=self, title="Warning",
+                parent=self,
+                title="Warning",
                 text=(
                     "Some actions are still in progress!<br>"
                     + "\n".join([f" - {item}<br>" for worker, item in busy.items()])
                     + "Are you sure you want to quit?"
                 ),
-                accept_text="Yes", cancel_text="No")
+                accept_text="Yes",
+                cancel_text="No",
+            )
 
             self.dlg.accepted.connect(self.destroy)
             return
@@ -620,7 +657,6 @@ class BlenderLauncher(BaseWindow):
             return True
         return False
 
-
     def destroy(self):
         self.quit_signal.emit()
 
@@ -634,8 +670,7 @@ class BlenderLauncher(BaseWindow):
         self.set_status("Reading local builds", False)
 
         if clear:
-            self.cm = ConnectionManager(
-                version=version, proxy_type=get_proxy_type())
+            self.cm = ConnectionManager(version=version, proxy_type=get_proxy_type())
             self.cm.setup()
             self.cm.error.connect(self.connection_error)
             self.manager = self.cm.manager
@@ -655,6 +690,7 @@ class BlenderLauncher(BaseWindow):
         self.LibraryDailyListWidget.clear_()
         self.LibraryExperimentalListWidget.clear_()
         self.UserCustomListWidget.clear_()
+        self.PreferancesListWidget.clear_()
 
         self.library_drawer = DrawLibraryAction()
         self.library_drawer.found.connect(self.draw_to_library)
@@ -663,6 +699,7 @@ class BlenderLauncher(BaseWindow):
             self.library_drawer.finished.connect(self.draw_downloads)
 
         self.action_queue.append(self.library_drawer)
+
     def reload_custom_builds(self):
         self.UserCustomListWidget.clear_()
 
@@ -670,7 +707,6 @@ class BlenderLauncher(BaseWindow):
         self.library_drawer.found.connect(self.draw_to_library)
         self.library_drawer.unrecognized.connect(self.draw_unrecognized)
         self.action_queue.append(self.library_drawer)
-
 
     def draw_downloads(self):
         self.set_status("Checking for new builds", False)
@@ -702,9 +738,7 @@ class BlenderLauncher(BaseWindow):
 
     def scraper_finished(self):
         if self.new_downloads and not self.started:
-            self.show_message(
-                "New builds of Blender are available!",
-                message_type=MessageType.NEWBUILDS)
+            self.show_message("New builds of Blender are available!", message_type=MessageType.NEWBUILDS)
 
         for list_widget in self.DownloadsToolBox.list_widgets:
             for widget in list_widget.widgets.copy():
@@ -759,9 +793,7 @@ class BlenderLauncher(BaseWindow):
 
         if not downloads_list_widget.contains_build_info(build_info):
             item = BaseListWidgetItem(build_info.commit_time)
-            widget = DownloadWidget(
-                self, downloads_list_widget, item,
-                build_info, show_new, is_installed)
+            widget = DownloadWidget(self, downloads_list_widget, item, build_info, show_new, is_installed)
             downloads_list_widget.add_item(item, widget)
             if is_installed:
                 self.new_downloads = True
@@ -781,10 +813,8 @@ class BlenderLauncher(BaseWindow):
             return
 
         item = BaseListWidgetItem()
-        widget = LibraryWidget(self, item, path, list_widget,
-                               show_new)
+        widget = LibraryWidget(self, item, path, list_widget, show_new)
         list_widget.insert_item(item, widget)
-
 
     def draw_unrecognized(self, path):
         branch = Path(path).parent.name
@@ -826,9 +856,7 @@ class BlenderLauncher(BaseWindow):
             if latest_tag not in self.notification_pool:
                 self.NewVersionButton.setText(f"Update to version {latest_tag.replace('v', '')}")
                 self.NewVersionButton.show()
-                self.show_message(
-                    "New version of Blender Launcher is available!",
-                    value=latest_tag)
+                self.show_message("New version of Blender Launcher is available!", value=latest_tag)
 
             self.latest_tag = latest_tag
 
@@ -868,12 +896,16 @@ class BlenderLauncher(BaseWindow):
 
         if str(data, encoding="ascii") != self.version:
             self.dlg = DialogWindow(
-                parent=self, title="Warning",
+                parent=self,
+                title="Warning",
                 text="An attempt to launch a different version<br>\
                       of Blender Launcher was detected!<br>\
                       Please, terminate currently running<br>\
                       version to proceed this action!",
-                accept_text="OK", cancel_text=None, icon=DialogIcon.WARNING)
+                accept_text="OK",
+                cancel_text=None,
+                icon=DialogIcon.WARNING,
+            )
 
     def open_docs(self):
         webbrowser.open("https://Victor-IX.github.io/Blender-Launcher-V2")
@@ -888,7 +920,7 @@ class BlenderLauncher(BaseWindow):
         print(e.mimeData().text())
 
     def restart_app(self):
-        """ Launch 'Blender Launcher.exe' and exit """
+        """Launch 'Blender Launcher.exe' and exit"""
         cwd = get_cwd()
 
         if self.platform == "Windows":

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -359,7 +359,7 @@ class BlenderLauncher(BaseWindow):
         self.statusbarVersion = QPushButton(self.version)
         self.statusbarVersion.clicked.connect(self.show_changelog)
         self.statusbarVersion.setToolTip(
-            "The version of Blender Launcher that is currently run. " "Press to check changelog."
+            "The version of Blender Launcher that is currently run. Press to check changelog."
         )
         self.status_bar.addPermanentWidget(self.ForceCheckNewBuilds)
         self.status_bar.addPermanentWidget(QLabel("│"))


### PR DESCRIPTION
## Branch to work on #39

I was thinking about creating a new tab to manage multiple Blender preferences for the installed Blender version. 
We can integrate a similar system as for the custom build initialization to initialize Blender preferences.

I checked what was made for the Blender Template, but I feel like it will be easier to do it from scratch.

From my point of view, the "safest" solution to managing multiple preferences for a Blender version will be to directly move the entire preferences folder (version folder presents `Blender Foundation\Blender`) between the Template folder from the Blender launcher to the source folder. 
Changing the environment variable seems to be a very good idea and much cleaner, but I'm afraid it can cause issues if you have your library in a specific folder.  
Maybe we can have both and have a setting for that...

## We need:
- Preference Initialization to add the custom name and gather the needed info
- Option to duplicate Save Preferences
- Option to create default Preferences  
- Making sure Blender is not running when swapping Preferences

## UI Example

![Untitled-1](https://github.com/Victor-IX/Blender-Launcher-V2/assets/56182681/748d7927-0c52-485e-aea5-2e6424052103)
