### PR TITLE
Rename actions to tasks

### DIFF
--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from modules._platform import _check_output, get_platform, set_locale
-from modules.action import Action
+from modules.task import Task
 from PyQt5.QtCore import QThread, pyqtSignal
 
 if TYPE_CHECKING:
@@ -181,7 +181,7 @@ def read_blender_version(
 
 
 @dataclass(frozen=True)
-class WriteBuildAction(Action):
+class WriteBuildTask(Task):
     written = pyqtSignal()
     error = pyqtSignal()
 
@@ -231,7 +231,7 @@ def read_build_info(path: Path, archive_name: str | None = None, custom_exe: str
 
 
 @dataclass(frozen=True)
-class ReadBuildAction(Action):
+class ReadBuildTask(Task):
     path: Path
     archive_name: str | None = None
     custom_exe: str | None = None

--- a/source/modules/task.py
+++ b/source/modules/task.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from PyQt5.QtCore import QObject
 
 
-class Action(QObject):
+class Task(QObject):
     def __post_init__(self):
         super().__init__()
 

--- a/source/threads/downloader.py
+++ b/source/threads/downloader.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from modules._copyfileobj import copyfileobj
-from modules.action import Action
+from modules.task import Task
 from modules.connection_manager import REQUEST_MANAGER
 from modules.settings import get_library_folder
 from PyQt5.QtCore import pyqtSignal
@@ -33,7 +33,7 @@ def download(
 
 
 @dataclass(frozen=True)
-class DownloadAction(Action):
+class DownloadTask(Task):
     manager: REQUEST_MANAGER
     link: str
     progress = pyqtSignal(int, int)

--- a/source/threads/extractor.py
+++ b/source/threads/extractor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from modules._platform import _check_call
-from modules.action import Action
+from modules.task import Task
 from PyQt5.QtCore import pyqtSignal
 
 
@@ -55,7 +55,7 @@ def extract(source: Path, destination: Path, progress_callback: Callable[[int, i
 
 
 @dataclass(frozen=True)
-class ExtractAction(Action):
+class ExtractTask(Task):
     file: Path
     destination: Path
 

--- a/source/threads/library_drawer.py
+++ b/source/threads/library_drawer.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from modules._platform import get_platform
-from modules.action import Action
 from modules.settings import get_library_folder
+from modules.task import Task
 from PyQt5.QtCore import pyqtSignal
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class DrawLibraryAction(Action):
+class DrawLibraryTask(Task):
     folders: Iterable[str | Path] = ("stable", "daily", "experimental", "custom")
     found = pyqtSignal(Path)
     unrecognized = pyqtSignal(Path)

--- a/source/threads/remover.py
+++ b/source/threads/remover.py
@@ -2,12 +2,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from shutil import rmtree
 
-from modules.action import Action
+from modules.task import Task
 from PyQt5.QtCore import pyqtSignal
 
 
 @dataclass
-class RemoveAction(Action):
+class RemovalTask(Task):
     path: Path
     finished = pyqtSignal(bool)
 

--- a/source/threads/renamer.py
+++ b/source/threads/renamer.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-from modules.action import Action
+from modules.task import Task
 from PyQt5.QtCore import pyqtSignal
 
 
 @dataclass(frozen=True)
-class RenameAction(Action):
+class RenameTask(Task):
     src: Path
     dst_name: str
 

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -107,7 +107,7 @@ class Scraper(QThread):
             build_var = build["branch"]
         if build_var:
             subversion = f"{subversion} {build_var}"
-
+        print(build)
         return BuildInfo(
             build["url"],
             subversion,

--- a/source/threads/template_installer.py
+++ b/source/threads/template_installer.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from re import match
 from shutil import copytree
 
-from modules.action import Action
 from modules.settings import get_library_folder
+from modules.task import Task
 from PyQt5.QtCore import pyqtSignal
 
 
@@ -25,7 +25,7 @@ def install_template(dist: Path):
 
 
 @dataclass(frozen=True)
-class TemplateAction(Action):
+class TemplateTask(Task):
     destination: Path
 
     finished = pyqtSignal()

--- a/source/windows/custom_build_dialog_window.py
+++ b/source/windows/custom_build_dialog_window.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from modules._platform import get_platform
-from modules.build_info import BuildInfo, ReadBuildAction
+from modules.build_info import BuildInfo, ReadBuildTask
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QCheckBox,
@@ -236,10 +236,10 @@ class CustomBuildDialogWindow(BaseWindow):
         self.accept_button.setEnabled(is_chosen)
 
     def auto_detect_info(self):
-        a = ReadBuildAction(self.path, custom_exe=self.executable_choice.text(), auto_write=False)
+        a = ReadBuildTask(self.path, custom_exe=self.executable_choice.text(), auto_write=False)
         a.finished.connect(self.load_from_build_info)
         a.failure.connect(self.auto_detect_failed)
-        self.parent_.action_queue.append(a)
+        self.parent_.task_queue.append(a)
         self.auto_detect_button.setEnabled(False)
 
     def load_from_build_info(self, binfo: BuildInfo):

--- a/source/windows/update_window.py
+++ b/source/windows/update_window.py
@@ -6,11 +6,11 @@ from typing import TypedDict
 
 import distro
 from modules._platform import _popen, get_cwd, get_platform
-from modules.actions import ActionQueue
+from modules.tasks import TaskQueue
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
-from threads.downloader import DownloadAction
-from threads.extractor import ExtractAction
+from threads.downloader import DownloadTask
+from threads.extractor import ExtractTask
 from widgets.base_progress_bar_widget import BaseProgressBarWidget
 from windows.base_window import BaseWindow
 
@@ -58,7 +58,7 @@ class BlenderLauncherUpdater(BaseWindow):
         self.platform = get_platform()
         self.cwd = get_cwd()
 
-        self.queue = ActionQueue(parent=self, worker_count=1)
+        self.queue = TaskQueue(parent=self, worker_count=1)
         self.queue.start()
 
         self.show()
@@ -103,14 +103,14 @@ class BlenderLauncherUpdater(BaseWindow):
 
         assert self.manager is not None
         self.ProgressBar.set_title("Downloading")
-        a = DownloadAction(self.manager, link)
+        a = DownloadTask(self.manager, link)
         a.progress.connect(self.ProgressBar.set_progress)
         a.finished.connect(self.extract)
         self.queue.append(a)
 
     def extract(self, source):
         self.ProgressBar.set_title("Extracting")
-        a = ExtractAction(source, self.cwd)
+        a = ExtractTask(source, self.cwd)
         a.progress.connect(self.ProgressBar.set_progress)
         a.finished.connect(self.finish)
         self.queue.append(a)


### PR DESCRIPTION
QT already has QActions, and I forgot about them as I was creating the Actions and the Action queue
I made this pr because It feels like confusion will arise from having two things having the same name and doing very different things
This isn't a very important change as it's simply a renaming, so if we want to just ditch this it's fine imo