### PR TITLE
add shortcut to --use-last by holding shift while triggering a launch

### DIFF
--- a/source/modules/icons.py
+++ b/source/modules/icons.py
@@ -22,6 +22,7 @@ class Icons:
     download: QIcon
     file: QIcon
     taskbar: QIcon
+    none: QIcon
 
     @classmethod
     def get(cls, color=WHITE):
@@ -39,6 +40,7 @@ class Icons:
             load_icon(color, "download"),
             load_icon(color, "file"),
             QIcon(base_path + "bl/bl.ico"),
+            QIcon(),
         )
 
 

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -124,6 +124,7 @@ class LibraryWidget(BaseBuildWidget):
         self.launchButton = LeftIconButtonWidget("Launch")
         self.launchButton.setFixedWidth(85)
         self.launchButton.setProperty("LaunchButton", True)
+        self._launch_icon = None
 
         if self.branch == "lts":
             branch_name = "LTS"
@@ -161,7 +162,9 @@ class LibraryWidget(BaseBuildWidget):
         self.layout.addWidget(self.commitTimeLabel)
         self.layout.addWidget(self.build_state_widget)
 
-        self.launchButton.clicked.connect(lambda: self.launch(update_selection=True, open_last=self.hovering_and_shifting))
+        self.launchButton.clicked.connect(
+            lambda: self.launch(update_selection=True, open_last=self.hovering_and_shifting)
+        )
         self.launchButton.setCursor(Qt.CursorShape.PointingHandCursor)
 
         # Context menu
@@ -171,6 +174,12 @@ class LibraryWidget(BaseBuildWidget):
         self.deleteAction = QAction("Delete From Drive", self)
         self.deleteAction.setIcon(self.parent.icons.delete)
         self.deleteAction.triggered.connect(self.ask_remove_from_drive)
+
+        self.openRecentAction = QAction("Open previous file", self)
+        self.openRecentAction.setIcon(self.parent.icons.file)
+        self.openRecentAction.triggered.connect(lambda: self.launch(open_last=True))
+        self.openRecentAction.setToolTip("This action opens the last file used in this build."
+                                        "<br>(Appends `--open-last` to the execution arguments)")
 
         self.addToQuickLaunchAction = QAction("Add To Quick Launch", self)
         self.addToQuickLaunchAction.setIcon(self.parent.icons.quick_launch)
@@ -224,6 +233,7 @@ class LibraryWidget(BaseBuildWidget):
         self.debugMenu.addAction(self.debugGpuTemplateAction)
         self.debugMenu.addAction(self.debugGpuGWTemplateAction)
 
+        self.menu.addAction(self.openRecentAction)
         self.menu.addAction(self.addToQuickLaunchAction)
         self.menu.addAction(self.addToFavoritesAction)
         self.menu.addAction(self.removeFromFavoritesAction)
@@ -297,7 +307,7 @@ class LibraryWidget(BaseBuildWidget):
 
     def mouseDoubleClickEvent(self, event):
         if self.build_info is not None:
-            self.launch(update_selection=True, open_last=self.hovering_and_shifting)
+            self.launch(open_last=self.hovering_and_shifting)
 
     def mouseReleaseEvent(self, event):
         if event.button == Qt.MouseButton.LeftButton:
@@ -349,10 +359,16 @@ class LibraryWidget(BaseBuildWidget):
         return super().eventFilter(obj, event)
 
     def _shift_hovering(self):
-        self.launchButton.set_text("Last?")
+        self.launchButton.set_text("  Previous")
+        self._launch_icon = self.launchButton.icon()
+        self.launchButton.setIcon(self.parent.icons.file)
+        self.launchButton.setFont(self.parent.font_8)
+
 
     def _stopped_shift_hovering(self):
         self.launchButton.set_text("Launch")
+        self.launchButton.setIcon(self._launch_icon or self.parent.icons.none)
+        self.launchButton.setFont(self.parent.font_10)
 
     def enterEvent(self, e):
         self._hovered = True

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -178,8 +178,10 @@ class LibraryWidget(BaseBuildWidget):
         self.openRecentAction = QAction("Open Previous File", self)
         self.openRecentAction.setIcon(self.parent.icons.file)
         self.openRecentAction.triggered.connect(lambda: self.launch(open_last=True))
-        self.openRecentAction.setToolTip("This action opens the last file used in this build."
-                                        "<br>(Appends `--open-last` to the execution arguments)")
+        self.openRecentAction.setToolTip(
+            "This action opens the last file used in this build."
+            "<br>(Appends `--open-last` to the execution arguments)"
+        )
 
         self.addToQuickLaunchAction = QAction("Add To Quick Launch", self)
         self.addToQuickLaunchAction.setIcon(self.parent.icons.quick_launch)
@@ -363,7 +365,6 @@ class LibraryWidget(BaseBuildWidget):
         self._launch_icon = self.launchButton.icon()
         self.launchButton.setIcon(self.parent.icons.file)
         self.launchButton.setFont(self.parent.font_8)
-
 
     def _stopped_shift_hovering(self):
         self.launchButton.set_text("Launch")

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -180,7 +180,8 @@ class LibraryWidget(BaseBuildWidget):
         self.openRecentAction.triggered.connect(lambda: self.launch(open_last=True))
         self.openRecentAction.setToolTip(
             "This action opens the last file used in this build."
-            "<br>(Appends `--open-last` to the execution arguments)"
+            "\n(Appends `--open-last` to the execution arguments)"
+            "\nSHORTCUT: Shift + Launch or Doubleclick"
         )
 
         self.addToQuickLaunchAction = QAction("Add To Quick Launch", self)

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -175,7 +175,7 @@ class LibraryWidget(BaseBuildWidget):
         self.deleteAction.setIcon(self.parent.icons.delete)
         self.deleteAction.triggered.connect(self.ask_remove_from_drive)
 
-        self.openRecentAction = QAction("Open previous file", self)
+        self.openRecentAction = QAction("Open Previous File", self)
         self.openRecentAction.setIcon(self.parent.icons.file)
         self.openRecentAction.triggered.connect(lambda: self.launch(open_last=True))
         self.openRecentAction.setToolTip("This action opens the last file used in this build."

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -161,7 +161,7 @@ class LibraryWidget(BaseBuildWidget):
         self.layout.addWidget(self.commitTimeLabel)
         self.layout.addWidget(self.build_state_widget)
 
-        self.launchButton.clicked.connect(lambda: self.launch(True))
+        self.launchButton.clicked.connect(lambda: self.launch(update_selection=True, open_last=self.hovering_and_shifting))
         self.launchButton.setCursor(Qt.CursorShape.PointingHandCursor)
 
         # Context menu
@@ -297,7 +297,7 @@ class LibraryWidget(BaseBuildWidget):
 
     def mouseDoubleClickEvent(self, event):
         if self.build_info is not None:
-            self.launch()
+            self.launch(update_selection=True, open_last=self.hovering_and_shifting)
 
     def mouseReleaseEvent(self, event):
         if event.button == Qt.MouseButton.LeftButton:
@@ -340,9 +340,9 @@ class LibraryWidget(BaseBuildWidget):
         self.setStyleSheet("background-color:")
 
     def eventFilter(self, obj, event):
-        # For detecting ALT
+        # For detecting SHIFT
         if isinstance(event, QHoverEvent):
-            if self._hovered and event.modifiers() & Qt.Modifier.ALT:
+            if self._hovered and event.modifiers() & Qt.Modifier.SHIFT:
                 self.hovering_and_shifting = True
             else:
                 self.hovering_and_shifting = False
@@ -388,7 +388,7 @@ class LibraryWidget(BaseBuildWidget):
         self.deleteAction.setEnabled(True)
         self.installTemplateAction.setEnabled(True)
 
-    def launch(self, update_selection=False, exe=None, blendfile: Path | None = None):
+    def launch(self, update_selection=False, exe=None, blendfile: Path | None = None, open_last=False):
         assert self.build_info is not None
         if update_selection is True:
             self.list_widget.clearSelection()
@@ -453,7 +453,7 @@ class LibraryWidget(BaseBuildWidget):
             else:
                 args += f' "{blendfile.as_posix()}"'
 
-        if self.hovering_and_shifting:
+        if open_last:
             if isinstance(args, list):
                 args.append("--open-last")
             else:


### PR DESCRIPTION
Related to #58 and #60


0:00 launching normally
0:12 Saving project
0:19 launching normally again
0:28 while holding alt, launching with the last file loaded


https://github.com/Victor-IX/Blender-Launcher-V2/assets/54873330/b8a45032-b1a2-4c33-ba0e-e43139c684a7

