### PR TITLE
add option to use system title bar

### DIFF
--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -390,3 +390,9 @@ def get_worker_thread_count() -> int:
 
 def set_worker_thread_count(v: int):
     get_settings().setValue("worker_thread_count", v)
+
+def get_use_system_titlebar():
+    return get_settings().value("use_system_title_bar", defaultValue=False, type=bool)
+
+def set_use_system_titlebar(b: bool):
+    get_settings().setValue("use_system_title_bar", b)

--- a/source/widgets/settings_window/general_tab.py
+++ b/source/widgets/settings_window/general_tab.py
@@ -10,6 +10,7 @@ from modules.settings import (
     get_new_builds_check_frequency,
     get_platform,
     get_show_tray_icon,
+    get_use_system_titlebar,
     get_worker_thread_count,
     set_check_for_new_builds_automatically,
     set_enable_high_dpi_scaling,
@@ -19,6 +20,7 @@ from modules.settings import (
     set_make_error_popup,
     set_new_builds_check_frequency,
     set_show_tray_icon,
+    set_use_system_titlebar,
     set_worker_thread_count,
 )
 from PyQt5.QtCore import Qt
@@ -65,6 +67,11 @@ class GeneralTabWidget(SettingsFormWidget):
         self.ShowTrayIconCheckBox = QCheckBox()
         self.ShowTrayIconCheckBox.setChecked(get_show_tray_icon())
         self.ShowTrayIconCheckBox.clicked.connect(self.toggle_show_tray_icon)
+
+        # Use System Title Bar
+        self.UseSystemTitleBar = QCheckBox()
+        self.UseSystemTitleBar.setChecked(get_use_system_titlebar())
+        self.UseSystemTitleBar.clicked.connect(self.toggle_system_titlebar)
 
         # New Builds Check Settings
         self.CheckForNewBuildsAutomatically = QCheckBox()
@@ -120,6 +127,7 @@ class GeneralTabWidget(SettingsFormWidget):
             self._addRow("Launch When System Starts", self.LaunchWhenSystemStartsCheckBox)
 
         self._addRow("Show Tray Icon", self.ShowTrayIconCheckBox)
+        self._addRow("Use System Title Bar", self.UseSystemTitleBar)
 
         self.LaunchMinimizedToTrayRow = self._addRow("Launch Minimized To Tray", self.LaunchMinimizedToTrayCheckBox)
         self.LaunchMinimizedToTrayRow.setEnabled(get_show_tray_icon())
@@ -160,6 +168,10 @@ class GeneralTabWidget(SettingsFormWidget):
         set_show_tray_icon(is_checked)
         self.LaunchMinimizedToTrayRow.setEnabled(is_checked)
         self.parent.tray_icon.setVisible(is_checked)
+
+    def toggle_system_titlebar(self, is_checked):
+        set_use_system_titlebar(is_checked)
+        self.parent.update_system_titlebar(is_checked)
 
     def toggle_check_for_new_builds_automatically(self, is_checked):
         set_check_for_new_builds_automatically(is_checked)

--- a/source/windows/base_window.py
+++ b/source/windows/base_window.py
@@ -53,6 +53,14 @@ class BaseWindow(QMainWindow):
         self.destroyed.connect(lambda: self._destroyed())
 
     def set_system_titlebar(self, b: bool):
+        """
+        Changes window flags so frameless is enabled (custom headers) or disabled (system).
+
+        This is called during initialization. use update_system_titlebar(b: bool) to update window components.
+
+        Arguments:
+            b -- bool
+        """
         if not b:
             self.setWindowFlags(Qt.WindowType.FramelessWindowHint)
             if self.using_system_bar:
@@ -60,13 +68,20 @@ class BaseWindow(QMainWindow):
                 self.show()
             self.using_system_bar = False
         else:
-            self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.FramelessWindowHint) # type: ignore
+            self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.FramelessWindowHint)  # type: ignore
             if not self.using_system_bar:
                 self.hide()
                 self.show()
             self.using_system_bar = True
 
     def update_system_titlebar(self, b: bool):
+        """
+        Used to update window components, such as the header, when swapping between the system title bar and
+        the custom one
+
+        Arguments:
+            b -- bool
+        """
         ...
 
     def mousePressEvent(self, event):

--- a/source/windows/base_window.py
+++ b/source/windows/base_window.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from modules.connection_manager import ConnectionManager
 from modules.icons import Icons
-from modules.settings import get_enable_high_dpi_scaling
+from modules.settings import get_enable_high_dpi_scaling, get_use_system_titlebar
 from PyQt5.QtCore import QFile, QPoint, Qt, QTextStream
 from PyQt5.QtGui import QFont, QFontDatabase
 from PyQt5.QtWidgets import QApplication, QMainWindow
@@ -43,13 +43,31 @@ class BaseWindow(QMainWindow):
             self.style_sheet = QTextStream(file).readAll()
             self.app.setStyleSheet(self.style_sheet)
 
-        self.setWindowFlags(Qt.WindowType.FramelessWindowHint)
+        self.using_system_bar = get_use_system_titlebar()
+        self.set_system_titlebar(self.using_system_bar)
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
 
         self.pos = self.pos()
         self.pressing = False
 
         self.destroyed.connect(lambda: self._destroyed())
+
+    def set_system_titlebar(self, b: bool):
+        if not b:
+            self.setWindowFlags(Qt.WindowType.FramelessWindowHint)
+            if self.using_system_bar:
+                self.hide()
+                self.show()
+            self.using_system_bar = False
+        else:
+            self.setWindowFlags(self.windowFlags() & ~Qt.WindowType.FramelessWindowHint) # type: ignore
+            if not self.using_system_bar:
+                self.hide()
+                self.show()
+            self.using_system_bar = True
+
+    def update_system_titlebar(self, b: bool):
+        ...
 
     def mousePressEvent(self, event):
         self.pos = event.globalPos()

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -32,6 +32,7 @@ from modules.settings import (
     get_quick_launch_key_seq,
     get_show_tray_icon,
     get_sync_library_and_downloads_pages,
+    get_use_system_titlebar,
     get_worker_thread_count,
     is_library_folder_valid,
     set_library_folder,
@@ -42,6 +43,7 @@ from PyQt5.QtNetwork import QLocalServer
 from PyQt5.QtWidgets import (
     QAction,
     QApplication,
+    QHBoxLayout,
     QLabel,
     QPushButton,
     QStatusBar,
@@ -192,6 +194,15 @@ class BlenderLauncher(BaseWindow):
         else:
             self.app.quit()
 
+    def update_system_titlebar(self, b: bool):
+        for window in self.windows:
+            window.set_system_titlebar(b)
+            if window is not self:
+                window.update_system_titlebar(b)
+        self.header.setHidden(b)
+        self.corner_settings_widget.setHidden(not b)
+
+
     def draw(self, polish=False):
         # Header
         self.SettingsButton = WHeaderButton(self.icons.settings, "", self)
@@ -203,6 +214,21 @@ class BlenderLauncher(BaseWindow):
 
         self.SettingsButton.setProperty("HeaderButton", True)
         self.DocsButton.setProperty("HeaderButton", True)
+
+        self.corner_settings = QPushButton(self.icons.settings, "", self)
+        self.corner_settings.clicked.connect(self.show_settings_window)
+        self.corner_docs = QPushButton(self.icons.wiki, "", self)
+        self.corner_docs.clicked.connect(self.open_docs)
+
+
+        self.corner_settings_widget = QWidget(self)
+        # self.corner_settings_widget.setMaximumHeight(25)
+        self.corner_settings_widget.setContentsMargins(0, 0, 0, 0)
+        self.corner_settings_layout = QHBoxLayout(self.corner_settings_widget)
+        self.corner_settings_layout.addWidget(self.corner_docs)
+        self.corner_settings_layout.addWidget(self.corner_settings)
+        self.corner_settings_layout.setContentsMargins(0, 0, 0, 0)
+        self.corner_settings_layout.setSpacing(0)
 
 
         self.header = WindowHeader(
@@ -217,8 +243,10 @@ class BlenderLauncher(BaseWindow):
         # Tab layout
         self.TabWidget = QTabWidget()
         self.TabWidget.setProperty("North", True)
+        self.TabWidget.setCornerWidget(self.corner_settings_widget)
         self.CentralLayout.addWidget(self.TabWidget)
 
+        self.update_system_titlebar(get_use_system_titlebar())
         self.LibraryTab = QWidget()
         self.LibraryTabLayout = QVBoxLayout()
         self.LibraryTabLayout.setContentsMargins(0, 0, 0, 0)

--- a/source/windows/settings_window.py
+++ b/source/windows/settings_window.py
@@ -63,6 +63,7 @@ class SettingsWindow(BaseWindow):
         self.header = WindowHeader(self, "Settings", use_minimize=False)
         self.header.close_signal.connect(self._close)
         self.CentralLayout.addWidget(self.header)
+        self.update_system_titlebar(self.using_system_bar)
 
         # Tab Layout
         self.TabWidget = QTabWidget()
@@ -196,6 +197,9 @@ class SettingsWindow(BaseWindow):
 
     def restart_app(self):
         self.parent.restart_app()
+
+    def update_system_titlebar(self, b: bool):
+        self.header.setHidden(b)
 
     def _destroy(self):
         self.parent.settings_window = None


### PR DESCRIPTION
Making windows frameless have been creating a few issues on some Linux distributions. This allows users to disable the custom title bar if they feel like using the system default one is easier.

related to #52

https://github.com/Victor-IX/Blender-Launcher-V2/assets/54873330/af02f1b9-17d8-4f79-ba0b-4f869fcc300e

