### PR TITLE
Add checkboxes to scrape only stable or automated builds

### DIFF
--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -402,6 +402,19 @@ def set_minimum_blender_stable_version(v: float):
     get_settings().setValue("minimum_blender_stable_version", v)
 
 
+def get_scrape_stable_builds() -> bool:
+    return get_settings().value("scrape_stable_builds", defaultValue=True, type=bool)
+
+
+def set_scrape_stable_builds(b: bool):
+    get_settings().setValue("scrape_stable_builds", b)
+
+def get_scrape_automated_builds() -> bool:
+    return get_settings().value("scrape_automated_builds", defaultValue=True, type=bool)
+
+def set_scrape_automated_builds(b: bool):
+    get_settings().setValue("scrape_automated_builds", b)
+
 def get_make_error_popup():
     return get_settings().value("error_popup", defaultValue=True, type=bool)
 

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -52,6 +52,9 @@ class Scraper(QThread):
         self.hash = re.compile(r"\w{12}")
         self.subversion = re.compile(r"-\d\.[a-zA-Z0-9.]+-")
 
+        self.scrape_stable = get_scrape_stable_builds()
+        self.scrape_automated = get_scrape_automated_builds()
+
     def run(self):
         self.get_download_links()
         latest_tag = self.get_latest_tag()
@@ -80,9 +83,9 @@ class Scraper(QThread):
         set_locale()
 
         scrapers = []
-        if get_scrape_stable_builds():
+        if self.scrape_stable:
             scrapers.append(self.scrap_stable_releases())
-        if get_scrape_automated_builds():
+        if self.scrape_automated:
             scrapers.append(self.scrape_automated_releases())
         for build in chain(*scrapers):
             self.links.emit(build)

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin
 from bs4 import BeautifulSoup, SoupStrainer
 from modules._platform import get_platform, reset_locale, set_locale
 from modules.build_info import BuildInfo
-from modules.settings import get_minimum_blender_stable_version
+from modules.settings import get_minimum_blender_stable_version, get_scrape_automated_builds, get_scrape_stable_builds
 from PyQt5.QtCore import QThread, pyqtSignal
 
 if TYPE_CHECKING:
@@ -27,6 +27,7 @@ class Scraper(QThread):
     links = pyqtSignal(BuildInfo)
     new_bl_version = pyqtSignal(str)
     error = pyqtSignal()
+    stable_error = pyqtSignal(str)
 
     def __init__(self, parent, man):
         QThread.__init__(self)
@@ -78,12 +79,17 @@ class Scraper(QThread):
     def get_download_links(self):
         set_locale()
 
-        for build in chain(self.scrap_stable_releases(), self.gather_automated_builds()):
+        scrapers = []
+        if get_scrape_stable_builds():
+            scrapers.append(self.scrap_stable_releases())
+        if get_scrape_automated_builds():
+            scrapers.append(self.scrape_automated_releases())
+        for build in chain(*scrapers):
             self.links.emit(build)
 
         reset_locale()
 
-    def gather_automated_builds(self):
+    def scrape_automated_releases(self):
         base_fmt = "https://builder.blender.org/download/{}/?format=json&v=1"
         for branch_type in ("daily", "experimental", "patch"):
             url = base_fmt.format(branch_type)
@@ -203,6 +209,8 @@ class Scraper(QThread):
         releases = soup.find_all(href=b3d_link)
         if not any(releases):
             logger.info("Failed to gather stable releases")
+            logger.info(content)
+            self.stable_error.emit("No releases were scraped from the site!<br>check -debug logs for more details.")
 
         minimum_version = get_minimum_blender_stable_version()
 

--- a/source/widgets/settings_window/blender_builds_tab.py
+++ b/source/widgets/settings_window/blender_builds_tab.py
@@ -12,6 +12,8 @@ from modules.settings import (
     get_new_builds_check_frequency,
     get_platform,
     get_quick_launch_key_seq,
+    get_scrape_automated_builds,
+    get_scrape_stable_builds,
     set_bash_arguments,
     set_blender_startup_arguments,
     set_check_for_new_builds_automatically,
@@ -23,6 +25,8 @@ from modules.settings import (
     set_minimum_blender_stable_version,
     set_new_builds_check_frequency,
     set_quick_launch_key_seq,
+    set_scrape_automated_builds,
+    set_scrape_stable_builds,
 )
 from PyQt5 import QtGui
 from PyQt5.QtCore import Qt
@@ -77,12 +81,24 @@ class BlenderBuildsTabWidget(SettingsFormWidget):
         self.CheckForNewBuildsOnStartup.clicked.connect(self.toggle_check_on_startup)
         self.CheckForNewBuildsOnStartup.setText("On startup")
 
+        # Scraping builds settings
+        self.ScrapeStableBuilds = QCheckBox(self)
+        self.ScrapeStableBuilds.setChecked(get_scrape_stable_builds())
+        self.ScrapeStableBuilds.clicked.connect(self.toggle_scrape_stable_builds)
+        self.ScrapeStableBuilds.setText("Scrape stable builds")
+        self.ScrapeAutomatedBuilds = QCheckBox(self)
+        self.ScrapeAutomatedBuilds.setChecked(get_scrape_automated_builds())
+        self.ScrapeAutomatedBuilds.clicked.connect(self.toggle_scrape_automated_builds)
+        self.ScrapeAutomatedBuilds.setText("Scrape automated builds (daily/experimental/patch)")
+
         self.scraping_builds_layout = QGridLayout()
         self.scraping_builds_layout.addWidget(self.CheckForNewBuildsAutomatically, 0, 0, 1, 1)
         self.scraping_builds_layout.addWidget(self.NewBuildsCheckFrequency, 0, 1, 1, 1)
         self.scraping_builds_layout.addWidget(self.CheckForNewBuildsOnStartup, 1, 0, 1, 2)
         self.scraping_builds_layout.addWidget(QLabel("Minimum stable build to scrape", self), 2, 0, 1, 1)
         self.scraping_builds_layout.addWidget(self.MinStableBlenderVer, 2, 1, 1, 1)
+        self.scraping_builds_layout.addWidget(self.ScrapeStableBuilds, 3, 0, 1, 2)
+        self.scraping_builds_layout.addWidget(self.ScrapeAutomatedBuilds, 4, 0, 1, 2)
         self.buildcheck_settings.setLayout(self.scraping_builds_layout)
 
         # Downloading builds settings
@@ -233,3 +249,11 @@ class BlenderBuildsTabWidget(SettingsFormWidget):
     def toggle_check_on_startup(self, is_checked):
         set_check_for_new_builds_on_startup(is_checked)
         self.CheckForNewBuildsOnStartup.setChecked(is_checked)
+
+    def toggle_scrape_stable_builds(self, is_checked):
+        set_scrape_stable_builds(is_checked)
+        self.ScrapeStableBuilds.setChecked(is_checked)
+
+    def toggle_scrape_automated_builds(self, is_checked):
+        set_scrape_automated_builds(is_checked)
+        self.ScrapeAutomatedBuilds.setChecked(is_checked)


### PR DESCRIPTION
For some of us, it is a waste of time / bandwidth to scrape the stable builds because they usually use the daily/experimental builds, and on the flipside, some never intend to use the daily/experimental builds. These two options allow someone to just skip the different methods.