### PR TITLE
Make migrating settings to user config optional

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import modules._resources_rc
 from modules import argument_parsing as ap
-from modules._platform import _popen, get_cwd, get_launcher_name, get_platform, is_frozen, get_cache_path
+from modules._platform import _popen, get_cache_path, get_cwd, get_launcher_name, get_platform, is_frozen
 from PyQt5.QtWidgets import QApplication
 from windows.dialog_window import DialogWindow
 

--- a/source/modules/_platform.py
+++ b/source/modules/_platform.py
@@ -178,6 +178,7 @@ def get_cwd():
 
     return Path.cwd()
 
+
 @cache
 def get_config_path():
     platform = get_platform()
@@ -190,6 +191,24 @@ def get_config_path():
     if not config_path:
         return os.getcwd()
     return os.path.join(config_path, "Blender Launcher")
+
+
+@cache
+def local_config():
+    return get_cwd() / "Blender Launcher.ini"
+
+
+@cache
+def user_config():
+    return Path(get_config_path()) / "Blender Launcher.ini"
+
+
+def get_config_file():
+    # Prioritize local settings for portability
+    if (local := local_config()).exists():
+        return local
+    return user_config()
+
 
 @cache
 def get_cache_path():

--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -464,11 +464,11 @@ def set_use_system_titlebar(b: bool):
     get_settings().setValue("use_system_title_bar", b)
 
 
-def migrate_config():
+def migrate_config(force=False):
     config_path = Path(get_config_path())
     old_config = local_config()
     new_config = user_config()
-    if old_config.is_file() and not new_config.is_file():
+    if (old_config.is_file() and not new_config.is_file()) or force:
         if not config_path.is_dir():
             config_path.mkdir()
         shutil.move(old_config.resolve(), new_config.resolve())

--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -3,13 +3,12 @@ import os
 import shutil
 import sys
 from datetime import datetime, timezone
+from functools import cache
 from pathlib import Path
 
-from modules._platform import get_cwd, get_platform, get_config_path
+from modules._platform import get_config_file, get_config_path, get_cwd, get_platform, local_config, user_config
 from PyQt5.QtCore import QSettings
 from semver import Version
-
-from .build_info import parse_blender_ver
 
 ISO_EPOCH = datetime.fromtimestamp(0, tz=timezone.utc).isoformat()
 
@@ -62,10 +61,11 @@ proxy_types = {
 
 
 def get_settings():
-    config_path = Path(get_config_path())
-    if not config_path.is_dir():
-        config_path.mkdir()
-    return QSettings((config_path.absolute() / "Blender Launcher.ini").as_posix(), QSettings.Format.IniFormat)
+    file = get_config_file()
+    if not file.parent.is_dir():
+        file.parent.mkdir(parents=True)
+
+    return QSettings(get_config_file().as_posix(), QSettings.Format.IniFormat)
 
 
 def get_library_folder():
@@ -463,10 +463,11 @@ def get_use_system_titlebar():
 def set_use_system_titlebar(b: bool):
     get_settings().setValue("use_system_title_bar", b)
 
+
 def migrate_config():
     config_path = Path(get_config_path())
-    old_config = Path(get_cwd()) / "Blender Launcher.ini"
-    new_config = config_path     / "Blender Launcher.ini"
+    old_config = local_config()
+    new_config = user_config()
     if old_config.is_file() and not new_config.is_file():
         if not config_path.is_dir():
             config_path.mkdir()

--- a/source/widgets/settings_window/general_tab.py
+++ b/source/widgets/settings_window/general_tab.py
@@ -1,6 +1,7 @@
 import os
 
 from modules.settings import (
+    get_config_file,
     get_launch_minimized_to_tray,
     get_launch_when_system_starts,
     get_library_folder,
@@ -12,6 +13,7 @@ from modules.settings import (
     set_library_folder,
     set_show_tray_icon,
     set_worker_thread_count,
+    user_config,
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QCheckBox, QHBoxLayout, QLineEdit, QPushButton, QSpinBox, QWidget
@@ -92,6 +94,13 @@ class GeneralTabWidget(SettingsFormWidget):
 
         self._addRow("Worker Thread Count", self.WorkerThreadCount)
 
+        if get_config_file() != user_config():
+            button = QPushButton("Migrate local settings to user settings", self)
+            button.setProperty("CollapseButton", True)
+            button.clicked.connect(self.migrate_confirmation)
+
+            self.addRow(button)
+
     def set_library_folder(self):
         library_folder = str(get_library_folder())
         new_library_folder = FileDialogWindow().get_directory(self, "Select Library Folder", library_folder)
@@ -123,3 +132,5 @@ class GeneralTabWidget(SettingsFormWidget):
 
     def set_worker_thread_count(self):
         set_worker_thread_count(self.WorkerThreadCount.value())
+
+    def migrate_confirmation(self): ...

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -16,7 +16,7 @@ from time import localtime, mktime, strftime
 from typing import TYPE_CHECKING
 
 from items.base_list_widget_item import BaseListWidgetItem
-from modules._platform import _popen, get_cwd, get_launcher_name, get_platform, is_frozen, set_locale
+from modules._platform import _popen, get_cwd, get_launcher_name, get_platform, is_frozen
 from modules.connection_manager import ConnectionManager
 from modules.enums import MessageType
 from modules.settings import (
@@ -43,9 +43,6 @@ from modules.settings import (
     is_library_folder_valid,
     set_last_time_checked_utc,
     set_library_folder,
-    set_scrape_automated_builds,
-    set_scrape_stable_builds,
-    migrate_config,
 )
 from modules.tasks import Task, TaskQueue, TaskWorker
 from PyQt5.QtCore import QSize, Qt, pyqtSignal, pyqtSlot
@@ -172,7 +169,6 @@ class BlenderLauncher(BaseWindow):
         self.scraper.new_bl_version.connect(self.set_version)
         self.scraper.finished.connect(self.scraper_finished)
 
-        migrate_config()
         # Check library folder
         if is_library_folder_valid() is False:
             self.dlg = DialogWindow(
@@ -1041,6 +1037,5 @@ class BlenderLauncher(BaseWindow):
             # sys.executable should be something like /.../Blender Launcher.app/Contents/MacOS/Blender Launcher
             app = Path(sys.executable).parent.parent.parent
             _popen(f"open -n {shlex.quote(str(app))}")
-
 
         self.destroy()


### PR DESCRIPTION
This is sort of an extension to #88 that moved the config to the user settings. This was good, however it removed the ability for the application to be fully portable as the settings were bound to the user's account. This adds a button in the settings to migrate the file instead of the program doing so automatically