### PR TITLE
Add architecture displays to builds

### DIFF
--- a/source/modules/_platform.py
+++ b/source/modules/_platform.py
@@ -26,6 +26,10 @@ def get_platform():
 
 
 @cache
+def get_architecture():
+    return platform.machine()
+
+@cache
 def get_launcher_name():
     if sys.platform == "win32":
         return ("Blender Launcher.exe", "Blender Launcher Updater.exe")

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -4,7 +4,7 @@ import contextlib
 import json
 import logging
 import re
-import platform
+
 from datetime import datetime, timezone
 from itertools import chain
 from pathlib import Path

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -192,6 +192,8 @@ class Scraper(QThread):
             build_var = build["branch"]
 
         if "architecture" in build:
+            if build["architecture"] == "amd64":
+                build["architecture"] = "x86_64"
             build_var += " | " + build["architecture"]
 
         if build_var:

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import distro
 import contextlib
 import json
 import logging
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
+import distro
 import semver
 from bs4 import BeautifulSoup, SoupStrainer
 from modules._platform import get_platform, reset_locale, set_locale, stable_cache_path
@@ -190,6 +190,9 @@ class Scraper(QThread):
             build_var = build["release_cycle"]
         if build["branch"] and branch_type == "experimental":
             build_var = build["branch"]
+
+        if "architecture" in build:
+            build_var += " | " + build["architecture"]
 
         if build_var:
             subversion = subversion.replace(prerelease=build_var)


### PR DESCRIPTION
This adds an architecture notification to the branch string in certain builds, in the same style that MacOS builds are displayed.

![image](https://github.com/Victor-IX/Blender-Launcher-V2/assets/54873330/a4087322-af40-4c47-9378-f0157445017f)

- [x] Daily builds
- [ ] Builds in library


Would we want to add an architecture value to build infos?
