### PR TITLE
Add a message to notify the existence of tray icon feature

### DIFF
--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -280,6 +280,14 @@ def set_show_tray_icon(is_checked):
     get_settings().setValue("show_tray_icon", is_checked)
 
 
+def get_tray_icon_notified():
+    return get_settings().value("Internal/tray_icon_notified", defaultValue=False, type=bool)
+
+
+def set_tray_icon_notified(b=True):
+    get_settings().setValue("Internal/tray_icon_notified", b)
+
+
 def get_launch_blender_no_console():
     return get_settings().value("launch_blender_no_console", type=bool)
 

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -38,12 +38,14 @@ from modules.settings import (
     get_scrape_stable_builds,
     get_show_tray_icon,
     get_sync_library_and_downloads_pages,
+    get_tray_icon_notified,
     get_use_pre_release_builds,
     get_use_system_titlebar,
     get_worker_thread_count,
     is_library_folder_valid,
     set_last_time_checked_utc,
     set_library_folder,
+    set_tray_icon_notified,
 )
 from modules.tasks import Task, TaskQueue, TaskWorker
 from PyQt5.QtCore import QSize, Qt, pyqtSignal, pyqtSlot
@@ -638,7 +640,7 @@ class BlenderLauncher(BaseWindow):
             # Middle click currently return the Trigger reason
         elif reason == QSystemTrayIcon.ActivationReason.Context:
             self.tray_menu.trigger()
-            
+
     def _aboutToQuit(self):
         self.quit_()
 
@@ -988,6 +990,12 @@ class BlenderLauncher(BaseWindow):
 
     def closeEvent(self, event):
         if get_show_tray_icon():
+            if not get_tray_icon_notified():
+                self.show_message(
+                    "Blender Launcher V2 is minimized to the system tray. "
+                    '\nDisable "Show Tray Icon" in the settings to disable this.'
+                )
+                set_tray_icon_notified()
             event.ignore()
             self.hide()
             self.close_signal.emit()


### PR DESCRIPTION
Something I've noticed for a lot of people running it for a first time is they don't know about the system tray icon and understandably expects it to fully close when they close the window. What this does is make a message pop up the first time they close the app if they have tray icons enabled to make sure they actually know this is a feature

![image](https://github.com/Victor-IX/Blender-Launcher-V2/assets/54873330/7be56d16-8c40-47f0-bf63-828f2c025fcd)
