### PR TITLE
fix build error for linux

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,13 +1,13 @@
-cd..
+cd ..
 PYTHONOPTIMIZE=2 pyinstaller \
---hidden-import "pynput.keyboard._xorg" \
---hidden-import "pynput.mouse._xorg" \
---hidden-import "python-xlib" \
---clean \
---noconsole \
---noupx \
---onefile \
---name="Blender Launcher" \
---add-binary="source/resources/certificates/custom.pem:files" \
---distpath="./dist/release" \
-source/main.py
+	--hidden-import "pynput.keyboard._xorg" \
+	--hidden-import "pynput.mouse._xorg" \
+	--hidden-import "python-xlib" \
+	--clean \
+	--noconsole \
+	--noupx \
+	--onefile \
+	--name="Blender Launcher" \
+	--add-binary="source/resources/certificates/custom.pem:files" \
+	--distpath="./dist/release" \
+	source/main.py


### PR DESCRIPTION
get this error when building the package on linux

```
Using Python interpreter: /run/media/officestorage/karya/contrib/AUR/blender-launcher-git/src/Blender-Launcher-V2/lib/bin/python (3.9)
source /run/media/officestorage/karya/contrib/AUR/blender-launcher-git/src/Blender-Launcher-V2/lib/bin/activate
WARNING: Lockfile hash doesn't match pyproject.toml, packages may be outdated
Updating the lock file...
🔒 Lock successful
Changes are written to pdm.lock.
All packages are synced to date, nothing to do.
Installing the project as an editable package...
  ✔ Update blender-launcher-v2 2.1.24 -> 2.1.24 successful

🎉 All complete!

build_linux.sh: line 1: cd..: command not found
build_linux.sh: line 2: pyinstaller: command not found
==> ERROR: A failure occurred in build().
    Aborting...
```
it's typo on cd command, it should be writte with blank space before the target
