### PR TITLE
fix: scraped list not sorted

### DIFF
--- a/source/widgets/download_widget.py
+++ b/source/widgets/download_widget.py
@@ -129,6 +129,8 @@ class DownloadWidget(BaseBuildWidget):
                 self.showReleaseNotesAction.setText("Show Patch Details")
                 self.menu.addAction(self.showReleaseNotesAction)
 
+        self.list_widget.sortItems()
+
     def context_menu(self):
         if self.installed:
             self.installed.context_menu()


### PR DESCRIPTION
The list of scraped build is not being sorted when downloaded.

|  |  |  |  |  |  |  |  |  |
|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| NOT sorted | 4.x.x | 3.6.9 | 3.6.12 | 3.6.11 | 3.6.10 | ... |  3.3.9 | 3.3.1x |
| sorted | 4.x.x | 3.6.12 |  3.6.11 | 3.6.10 | 3.6.9 | ... | 3.3.1x | 3.3.9 |

Fix is just a 1 liner in the download widget.

I believe that just how they are listed and then get cough by the scraper.
I see the same "sort by first digit of patch number"  behaviour in the blender download pages [link](https://download.blender.org/release/Blender3.6/) .

---

https://github.com/Victor-IX/Blender-Launcher-V2/assets/21959185/b070f727-a061-4fe2-bdb0-7c1f17b1c51f 

https://github.com/Victor-IX/Blender-Launcher-V2/assets/21959185/9316bb0f-80cd-4569-a4b1-04d7708f29ce


