### PR TITLE
Allow relative library folders

### DIFF
--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -92,7 +92,7 @@ def get_library_folder():
         library_folder = get_cwd()
         settings.setValue("library_folder", library_folder)
 
-    return library_folder
+    return Path(library_folder).resolve()
 
 
 def is_library_folder_valid(library_folder=None):

--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -84,7 +84,7 @@ def get_settings():
     return QSettings(get_config_file().as_posix(), QSettings.Format.IniFormat)
 
 
-def get_library_folder():
+def get_actual_library_folder():
     settings = get_settings()
     library_folder = settings.value("library_folder")
 
@@ -92,7 +92,10 @@ def get_library_folder():
         library_folder = get_cwd()
         settings.setValue("library_folder", library_folder)
 
-    return Path(library_folder).resolve()
+    return Path(library_folder)
+
+def get_library_folder():
+    return get_actual_library_folder().resolve()
 
 
 def is_library_folder_valid(library_folder=None):
@@ -110,7 +113,7 @@ def is_library_folder_valid(library_folder=None):
     return False
 
 
-def set_library_folder(new_library_folder):
+def set_library_folder(new_library_folder: str):
     settings = get_settings()
 
     if is_library_folder_valid(new_library_folder) is True:

--- a/source/threads/library_drawer.py
+++ b/source/threads/library_drawer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/source/threads/library_drawer.py
+++ b/source/threads/library_drawer.py
@@ -32,7 +32,7 @@ class DrawLibraryTask(Task):
         }.get(platform, "blender")
 
         for folder in self.folders:
-            path = (library_folder / folder).resolve()
+            path = library_folder / folder
 
             if path.is_dir():
                 for build in path.iterdir():

--- a/source/threads/library_drawer.py
+++ b/source/threads/library_drawer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -31,7 +32,7 @@ class DrawLibraryTask(Task):
         }.get(platform, "blender")
 
         for folder in self.folders:
-            path = library_folder / folder
+            path = (library_folder / folder).resolve()
 
             if path.is_dir():
                 for build in path.iterdir():

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -185,30 +185,57 @@ class BlenderLauncher(BaseWindow):
                 cancel_text=None,
                 icon=DialogIcon.INFO,
             )
-            self.dlg.accepted.connect(self.set_library_folder)
+            self.dlg.accepted.connect(self.prompt_library_folder)
         else:
             create_library_folders(get_library_folder())
             self.draw()
 
-    def set_library_folder(self):
+    def prompt_library_folder(self):
         library_folder = get_cwd().as_posix()
         new_library_folder = FileDialogWindow().get_directory(self, "Select Library Folder", library_folder)
 
         if new_library_folder:
-            if set_library_folder(new_library_folder) is True:
-                self.draw(True)
-            else:
-                self.dlg = DialogWindow(
-                    parent=self,
-                    title="Warning",
-                    text="Selected folder is not valid or<br>\
-                    doesn't have write permissions!",
-                    accept_text="Retry",
-                    cancel_text=None,
-                )
-                self.dlg.accepted.connect(self.set_library_folder)
+            self.set_library_folder(Path(new_library_folder))
         else:
             self.app.quit()
+
+    def set_library_folder(self, folder: Path, relative: bool | None = None):
+        """
+        Sets the library folder.
+        if relative is None and the folder *can* be relative, it will ask the user if it should use a relative path.
+        if relative is bool, it will / will not set the library folder as relative.
+        """
+
+        if folder.is_relative_to(get_cwd()):
+            if relative is None:
+                self.dlg = DialogWindow(
+                    parent=self,
+                    title="Setup",
+                    text="The selected path is relative to the executable's path.<br>\
+                        Would you like to save it as relative?<br>\
+                        This is useful if the folder may move.",
+                    accept_text="Yes",
+                    cancel_text="No",
+                )
+                self.dlg.accepted.connect(lambda: self.set_library_folder(folder, True))
+                self.dlg.cancelled.connect(lambda: self.set_library_folder(folder, False))
+                return
+
+            if relative:
+                folder = folder.relative_to(get_cwd())
+
+        if set_library_folder(str(folder)) is True:
+            self.draw(True)
+        else:
+            self.dlg = DialogWindow(
+                parent=self,
+                title="Warning",
+                text="Selected folder is not valid or<br>\
+                doesn't have write permissions!",
+                accept_text="Retry",
+                cancel_text=None,
+            )
+            self.dlg.accepted.connect(self.prompt_library_folder)
 
     def update_system_titlebar(self, b: bool):
         for window in self.windows:


### PR DESCRIPTION
This small change allows for directing the library folder to a point relative to the launcher's location. This is useful if, say, you save your builds to a USB to use them anywhere or move them to a different folder, you don't need to change your library folder in the launcher for it to function.

Another adjustment I would like to do: During first-time startup, detect if the folder is relative to the launcher's location. if so, ask if it should be relative.
Edit: Finished that second adjustment. Tell me what you think!