### PR TITLE
move launching logic outside of LibraryWidget

### DIFF
--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -1,20 +1,27 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime
 from functools import cache
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-from modules._platform import _check_output, get_platform, reset_locale, set_locale
+from modules._platform import _check_output, _popen, get_platform, reset_locale, set_locale
+from modules.settings import (
+    get_bash_arguments,
+    get_blender_startup_arguments,
+    get_launch_blender_no_console,
+    get_library_folder,
+)
 from modules.task import Task
 from PyQt5.QtCore import pyqtSignal
 from semver import Version
 
-if TYPE_CHECKING:
-    from pathlib import Path
+logger = logging.getLogger()
+
 
 # TODO: Combine some of these
 matchers = tuple(
@@ -392,7 +399,6 @@ class ReadBuildTask(Task):
     path: Path
     info: BuildInfo | None = None
     archive_name: str | None = None
-    custom_exe: str | None = None
     auto_write: bool = True
 
     finished = pyqtSignal(BuildInfo)
@@ -409,3 +415,78 @@ class ReadBuildTask(Task):
 
     def __str__(self):
         return f"Read build at {self.path}"
+
+
+class LaunchMode: ...
+
+
+@dataclass(frozen=True)
+class LaunchWithBlendFile(LaunchMode):
+    blendfile: Path
+
+
+class LaunchOpenLast(LaunchMode): ...
+
+
+def launch_build(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None):
+    platform = get_platform()
+    library_folder = get_library_folder()
+    blender_args = get_blender_startup_arguments()
+
+    b3d_exe: Path
+    args: str | list[str] = ""
+    if platform == "Windows":
+        if exe is not None:
+            b3d_exe = library_folder / info.link / exe
+            args = ["cmd", "/C", b3d_exe.as_posix()]
+        else:
+            cexe = info.custom_executable
+            if cexe:
+                b3d_exe = library_folder / info.link / cexe
+            else:
+                if (
+                    get_launch_blender_no_console()
+                    and (launcher := (library_folder / info.link / "blender_launcher.exe")).exists()
+                ):
+                    b3d_exe = launcher
+                else:
+                    b3d_exe = library_folder / info.link / "blender.exe"
+
+            if blender_args == "":
+                args = [b3d_exe.as_posix()]
+            else:
+                args = [b3d_exe.as_posix(), *blender_args.split(" ")]
+
+    elif platform == "Linux":
+        bash_args = get_bash_arguments()
+
+        if bash_args != "":
+            bash_args += " "
+        bash_args += "nohup"
+
+        cexe = info.custom_executable
+        if cexe:
+            b3d_exe = library_folder / info.link / cexe
+        else:
+            b3d_exe = library_folder / info.link / "blender"
+
+        args = f'{bash_args} "{b3d_exe.as_posix()}" {blender_args}'
+
+    elif platform == "macOS":
+        b3d_exe = Path(info.link) / "Blender" / "Blender.app"
+        args = f"open -W -n {b3d_exe.as_posix()} --args"
+
+    if launch_mode is not None:
+        if isinstance(launch_mode, LaunchWithBlendFile):
+            if isinstance(args, list):
+                args.append(launch_mode.blendfile.as_posix())
+            else:
+                args += f' "{launch_mode.blendfile.as_posix()}"'
+        elif isinstance(launch_mode, LaunchOpenLast):
+            if isinstance(args, list):
+                args.append("--open-last")
+            else:
+                args += " --open-last"
+
+    logger.debug(f"Running build with args {args!s}")
+    return _popen(args)


### PR DESCRIPTION
Ideally the major features of BLV2 can be separated from the QT frontend. If that's accomplished, many parts of the launcher will not need to be loaded for certain aspects to still function. 

If you were to use Blender Launcher from the commandline to launch a certain build, all you will need is a list of builds and a method to launch them, no need to setup pool managers, scrape builds, etc.

(edit: I'm not sure why the fix i made before this pr was included in the history, but that's not part of this)