### PR TITLE
Connection header improvements 

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -106,6 +106,9 @@ def main():
     else:
         logging.root.setLevel(logging.INFO)
 
+    # Log Blender Launcher version
+    logger.info(f"Blender Launcher Version: {version}")
+
     # Create an instance of application and set its core properties
     app = QApplication([])
     app.setStyle("Fusion")

--- a/source/modules/_platform.py
+++ b/source/modules/_platform.py
@@ -40,7 +40,7 @@ def get_launcher_name():
 
 @cache
 def get_platform_full():
-    return f"{get_platform()} {os.name} {platform.release()}"
+    return f"{get_platform()}-{platform.release()}"
 
 
 def set_locale():

--- a/source/modules/connection_manager.py
+++ b/source/modules/connection_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ssl
 import sys
+import logging
 from typing import TYPE_CHECKING, Union
 
 from modules._platform import get_cwd, get_platform_full, is_frozen
@@ -12,6 +13,7 @@ from modules.settings import (
     get_proxy_type,
     get_proxy_user,
     get_use_custom_tls_certificates,
+    get_user_id,
 )
 from PyQt5.QtCore import QObject, pyqtSignal
 from urllib3 import PoolManager, ProxyManager, make_headers
@@ -19,6 +21,8 @@ from urllib3.contrib.socks import SOCKSProxyManager
 
 if TYPE_CHECKING:
     from semver import Version
+
+logger = logging.getLogger()
 
 proxy_types_chemes = {
     1: "http://",
@@ -47,8 +51,9 @@ class ConnectionManager(QObject):
         self.manager: REQUEST_MANAGER | None = None
 
         # Basic Headers
-        self._headers = {"user-agent": f"Blender-Launcher-v2/{self.version!s} ({get_platform_full()})"}
-
+        # TODO: Change back BLV2 to Blender-Launcher-v2 when it will be unblocked
+        self._headers = {"user-agent": f"BLV2/v.{self.version!s}/{get_platform_full()}/UserID-{get_user_id()}"}
+        logger.info(f"Connection Manager Header: {self._headers}")
         # Get custom certificates file path
         if is_frozen() is True:
             self.cacert = sys._MEIPASS + "/files/custom.pem"  # noqa: SLF001

--- a/source/modules/connection_manager.py
+++ b/source/modules/connection_manager.py
@@ -51,8 +51,7 @@ class ConnectionManager(QObject):
         self.manager: REQUEST_MANAGER | None = None
 
         # Basic Headers
-        # TODO: Change back BLV2 to Blender-Launcher-v2 when it will be unblocked
-        agent = f"BLV2/v.{self.version!s}/{get_platform_full()}/UserID-{get_user_id()}"
+        agent = f"Blender-Launcher-v2/v.{self.version!s}/{get_platform_full()}/UserID-{get_user_id()}"
         self._headers = {"user-agent": agent}
         logger.info(f"Connection Manager Header: {agent}")
         # Get custom certificates file path

--- a/source/modules/connection_manager.py
+++ b/source/modules/connection_manager.py
@@ -53,7 +53,7 @@ class ConnectionManager(QObject):
         # Basic Headers
         # TODO: Change back BLV2 to Blender-Launcher-v2 when it will be unblocked
         self._headers = {"user-agent": f"BLV2/v.{self.version!s}/{get_platform_full()}/UserID-{get_user_id()}"}
-        logger.info(f"Connection Manager Header: {self._headers}")
+        logger.info(f"Connection Manager Header: {list(self._headers.values())[0]}")
         # Get custom certificates file path
         if is_frozen() is True:
             self.cacert = sys._MEIPASS + "/files/custom.pem"  # noqa: SLF001

--- a/source/modules/connection_manager.py
+++ b/source/modules/connection_manager.py
@@ -52,8 +52,9 @@ class ConnectionManager(QObject):
 
         # Basic Headers
         # TODO: Change back BLV2 to Blender-Launcher-v2 when it will be unblocked
-        self._headers = {"user-agent": f"BLV2/v.{self.version!s}/{get_platform_full()}/UserID-{get_user_id()}"}
-        logger.info(f"Connection Manager Header: {list(self._headers.values())[0]}")
+        agent = f"BLV2/v.{self.version!s}/{get_platform_full()}/UserID-{get_user_id()}"
+        self._headers = {"user-agent": agent}
+        logger.info(f"Connection Manager Header: {agent}")
         # Get custom certificates file path
         if is_frozen() is True:
             self.cacert = sys._MEIPASS + "/files/custom.pem"  # noqa: SLF001

--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import shutil
 import sys
+import uuid
 from datetime import datetime, timezone
 from functools import cache
 from pathlib import Path
@@ -396,7 +397,11 @@ def set_use_custom_tls_certificates(is_checked):
 
 
 def get_user_id():
-    return get_settings().value("user_id", defaultValue="DefaultUserID", type=str).strip()
+    user_id = get_settings().value("user_id", type=str).strip()
+    if not user_id:
+        user_id = str(uuid.uuid4())
+        set_user_id(user_id)
+    return user_id
 
 
 def set_user_id(user_id):

--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -395,6 +395,15 @@ def set_use_custom_tls_certificates(is_checked):
     get_settings().setValue("use_custom_tls_certificates", is_checked)
 
 
+def get_user_id():
+    return get_settings().value("user_id", defaultValue="DefaultUserID", type=str).strip()
+
+
+def set_user_id(user_id):
+    get_settings().setValue("user_id", user_id.strip())
+
+
+# Blender Build Tab
 def get_check_for_new_builds_automatically():
     settings = get_settings()
 

--- a/source/widgets/settings_window/connection_tab.py
+++ b/source/widgets/settings_window/connection_tab.py
@@ -17,7 +17,7 @@ from modules.settings import (
 )
 from PyQt5 import QtGui
 from PyQt5.QtCore import QRegExp, Qt
-from PyQt5.QtWidgets import QCheckBox, QComboBox, QFormLayout, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout
+from PyQt5.QtWidgets import QCheckBox, QComboBox, QFormLayout, QHBoxLayout, QLabel, QLineEdit, QGridLayout
 from widgets.settings_form_widget import SettingsFormWidget
 
 from .settings_group import SettingsGroup
@@ -81,12 +81,14 @@ class ConnectionTabWidget(SettingsFormWidget):
         self.connection_authentication_settings = SettingsGroup("Connection Authentication", parent=self)
 
         # User ID
+        self.UserIDLabel = QLabel("User ID")
         self.UserIDLineEdit = QLineEdit()
         self.UserIDLineEdit.setText(get_user_id())
         self.UserIDLineEdit.editingFinished.connect(self.update_user_id)
 
-        self.connection_authentication_layout = QVBoxLayout()
-        self.connection_authentication_layout.addWidget(self.UserIDLineEdit)
+        self.connection_authentication_layout = QGridLayout()
+        self.connection_authentication_layout.addWidget(self.UserIDLabel, 0, 0, 1, 1)
+        self.connection_authentication_layout.addWidget(self.UserIDLineEdit, 0, 1, 1, 1)
         self.connection_authentication_settings.setLayout(self.connection_authentication_layout)
 
         # Layout

--- a/source/widgets/settings_window/connection_tab.py
+++ b/source/widgets/settings_window/connection_tab.py
@@ -5,6 +5,7 @@ from modules.settings import (
     get_proxy_type,
     get_proxy_user,
     get_use_custom_tls_certificates,
+    get_user_id,
     proxy_types,
     set_proxy_host,
     set_proxy_password,
@@ -12,10 +13,11 @@ from modules.settings import (
     set_proxy_type,
     set_proxy_user,
     set_use_custom_tls_certificates,
+    set_user_id,
 )
 from PyQt5 import QtGui
 from PyQt5.QtCore import QRegExp, Qt
-from PyQt5.QtWidgets import QCheckBox, QComboBox, QFormLayout, QHBoxLayout, QLabel, QLineEdit
+from PyQt5.QtWidgets import QCheckBox, QComboBox, QFormLayout, QHBoxLayout, QLabel, QLineEdit, QVBoxLayout
 from widgets.settings_form_widget import SettingsFormWidget
 
 from .settings_group import SettingsGroup
@@ -75,6 +77,18 @@ class ConnectionTabWidget(SettingsFormWidget):
         self.ProxyPasswordLineEdit.setEchoMode(QLineEdit.Password)
         self.ProxyPasswordLineEdit.editingFinished.connect(self.update_proxy_password)
 
+        # Connection Authentication
+        self.connection_authentication_settings = SettingsGroup("Connection Authentication", parent=self)
+
+        # User ID
+        self.UserIDLineEdit = QLineEdit()
+        self.UserIDLineEdit.setText(get_user_id())
+        self.UserIDLineEdit.editingFinished.connect(self.update_user_id)
+
+        self.connection_authentication_layout = QVBoxLayout()
+        self.connection_authentication_layout.addWidget(self.UserIDLineEdit)
+        self.connection_authentication_settings.setLayout(self.connection_authentication_layout)
+
         # Layout
         layout = QFormLayout()
         layout.addRow(self.UseCustomCertificatesCheckBox)
@@ -86,6 +100,8 @@ class ConnectionTabWidget(SettingsFormWidget):
         layout.addRow(QLabel("IP", self), sub_layout)
         layout.addRow(QLabel("Proxy User", self), self.ProxyUserLineEdit)
         layout.addRow(QLabel("Password", self), self.ProxyPasswordLineEdit)
+
+        self.addRow(self.connection_authentication_settings)
 
         self.proxy_settings.setLayout(layout)
         self.addRow(self.proxy_settings)
@@ -111,3 +127,7 @@ class ConnectionTabWidget(SettingsFormWidget):
     def update_proxy_password(self):
         password = self.ProxyPasswordLineEdit.text()
         set_proxy_password(password)
+
+    def update_user_id(self):
+        user_id = self.UserIDLineEdit.text()
+        set_user_id(user_id)

--- a/source/windows/settings_window.py
+++ b/source/windows/settings_window.py
@@ -8,6 +8,7 @@ from modules.settings import (
     get_proxy_port,
     get_proxy_type,
     get_proxy_user,
+    get_user_id,
     get_quick_launch_key_seq,
     get_use_custom_tls_certificates,
     get_worker_thread_count,
@@ -52,6 +53,7 @@ class SettingsWindow(BaseWindow):
         self.old_proxy_port = get_proxy_port()
         self.old_proxy_user = get_proxy_user()
         self.old_proxy_password = get_proxy_password()
+        self.old_user_id = get_user_id()
 
         self.old_check_for_new_builds_automatically = get_check_for_new_builds_automatically()
         self.old_new_builds_check_frequency = get_new_builds_check_frequency()
@@ -118,6 +120,7 @@ class SettingsWindow(BaseWindow):
         proxy_port = get_proxy_port()
         proxy_user = get_proxy_user()
         proxy_password = get_proxy_password()
+        user_id = get_user_id()
 
         # Restart app if any of the connection settings changed
         if self.old_use_custom_tls_certificates != use_custom_tls_certificates:
@@ -144,6 +147,9 @@ class SettingsWindow(BaseWindow):
 
         if self.old_proxy_password != proxy_password:
             pending_to_restart.append("Proxy Password")
+
+        if self.old_user_id != user_id:
+            pending_to_restart.append(f"User ID: {self.old_user_id}🠆{user_id}")
 
         """Update build check frequency"""
         check_for_new_builds_automatically = get_check_for_new_builds_automatically()


### PR DESCRIPTION
Blender Foundation is currently blocking requests to [download.blender.org](https://download.blender.org/). 
I improved the header and included a User ID (UUID4), so they can better monitor the workload caused by the Blender Launcher per user and block users causing too many requests.

