### PR TITLE
remove cache fallback

### DIFF
--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -326,11 +326,8 @@ class Scraper(QThread):
             logger.info("Failed to gather stable releases")
             logger.info(content)
             self.stable_error.emit(
-                "No releases were scraped from the site!<br>Using cached links.<br>check -debug logs for more details.<br>"
+                "No releases were scraped from the site!<br>check -debug logs for more details."
             )
-            # Use cached links
-            for build in self.cache.folders.values():
-                yield from build.assets
             return
 
         # Convert string to Verison


### PR DESCRIPTION
As we have experienced, this may have given the *buttons* to download the Blender versions but if the user decided to actually click it, it was likely the downloaded file would be invalid. The downloaded file would just contain the error messages given from the scraping step.

Related to #130: The error is not clear and is caused by this bug