### PR TITLE
Remove launch target

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -133,14 +133,6 @@ def main():
         help="Launch Blender from CLI. does not open any QT frontend. WARNING: LIKELY DOES NOT WORK IN WINDOWS BUNDLED EXECUTABLE",
     )
 
-    # This could be used better
-    launch_target_parser = subparsers.add_parser(
-        "__launch_target",
-        help="This is a target for launching the program from a shortcut.",
-        add_help=False,
-    )
-    launch_target_parser.add_argument("file", nargs="?", type=Path, help="Path to a specific Blender file to launch.")
-
     if sys.platform == "win32":
         subparsers.add_parser(
             "register",
@@ -148,7 +140,17 @@ def main():
         )
         subparsers.add_parser("unregister", help="Undoes the changes that `register` makes. (WIN ONLY)")
 
-    args, argv = parser.parse_known_args()
+    input_args = None
+
+    # Shortcut for launching
+    small_parser = ArgumentParser(add_help=False)
+    small_parser.add_argument("file", nargs="?", type=Path)
+    args, argv = small_parser.parse_known_args()
+    if args.file is not None and args.file.exists():
+        input_args = ["launch", "-f", str(args.file)]
+
+    args, argv = parser.parse_known_args(input_args)
+
     if argv:
         msg = _("unrecognized arguments: ") + " ".join(argv)
         ap.error(parser, msg)
@@ -180,8 +182,6 @@ def main():
 
     if args.command == "launch":
         start_launch(app, args.file, args.version, args.open_last, cli=args.cli)
-    if args.command == "__launch_target" and args.file:
-        start_launch(app, args.file, None, False)
 
     if args.command == "register":
         start_register()

--- a/source/modules/shortcut.py
+++ b/source/modules/shortcut.py
@@ -102,7 +102,7 @@ def register_windows_filetypes():
         else:
             pth = f'"{Path(sys.executable).resolve()}" "{Path(sys.argv[0]).resolve()}"'
 
-        winreg.SetValueEx(command_key, "", 0, winreg.REG_SZ, f'{pth} __launch_target "%1"')
+        winreg.SetValueEx(command_key, "", 0, winreg.REG_SZ, f'{pth} "%1"')
         logging.debug("Registered blenderlauncherv2.blend")
 
     # add it to the OpenWithProgids list
@@ -216,11 +216,11 @@ def generate_program_shortcut(destination: Path):
         exe = sys.executable
 
         wscript.Targetpath = exe
-        args = "__launch_target"
+        args = ""
         if not is_frozen():
             main_py = Path(sys.argv[0]).resolve()
 
-            args = f"{main_py} {args}"
+            args = str(main_py)
 
             # Icon location would be source/resources/icons/bl/bl.ico
             icon_loc = Path(main_py.parent, "resources", "icons", "bl", "bl.ico")
@@ -250,7 +250,7 @@ def generate_program_shortcut(destination: Path):
                 "[Desktop Entry]",
                 "Name=Blender Launcher V2",
                 "GenericName=Launcher",
-                f"Exec={_exec} __launch_target",
+                f"Exec={_exec}",
                 "MimeType=application/x-blender;",
                 "Icon=blender-icon",
                 "Terminal=false",


### PR DESCRIPTION
This simplifies the Open-With function by removing the __launch_target  command and replacing it with a separate parser that runs before the default parser. this accomplishes the "launching a file" functionality without needing an unintuitive middleman.

Theoretically, if someone has a file named "launch", or "register", etc. next to the launcher they will cause false positives. in the script, This could be mediated by checking the suffix of the given path if we want to cover this edge case.

Edit: I have not tested it on windows.