### PR TITLE
Filter stable mac builds to current architecture

### DIFF
--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -380,6 +380,15 @@ class Scraper(QThread):
                 branch = "daily"
                 subversion = subversion.replace(prerelease=build_var)
 
+        if self.platform == "macOS":
+            # Skip Intel builds on Apple Silicon
+            if self.architecture == "arm64" and "arm64" not in link:
+                return None
+
+            # Skip Apple Silicon builds on Intel
+            if self.architecture == "x64" and "x64" not in link:
+                return None
+
         commit_time = dateparser.parse(info["last-modified"]).astimezone()
         r.release_conn()
         r.close()


### PR DESCRIPTION
Prompted by: https://github.com/Victor-IX/Blender-Launcher-V2/issues/153#issuecomment-2453104799

Suggested by @xx88xx

@Victor-IX, how does Windows do this for the "stable" build side, I saw your PR #106 is targeted at "automated" releases.

This is just a suggestion of my very limited knowledge of the codebase, happy to move this code to somewhere more sensible. I've added code for x86, but there aren't many GH runners that run macos on intel - mostly if someone wanted to build it for themselves.