### PR TITLE
Add build action for MacOS 

### DIFF
--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -1,0 +1,53 @@
+name: MacOS Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          
+      - name: GitHub Tag
+        run: | 
+          echo "Tag name from github.ref_name: ${{  github.ref_name }}"
+
+      - name: Setup + Build + Zip
+        run: |
+          # replace the pyqt requirements in pyproject.toml
+          sed -i '' 's/pyqt5-qt5==/pyqt5-qt5>=/' pyproject.toml
+
+          echo "Venv setup"
+          python -m venv .venv
+          source ./.venv/bin/activate
+          
+          echo "Installing dependencies"
+          pip install -e ./
+          
+          echo "Building style"
+          python build_style.py
+          
+          echo "Building application"
+          cd scripts
+          bash build_mac.sh
+          
+          echo "Zipping to Blender_Launcher_${{ github.ref_name }}_macos_arm64.zip"
+          cd ../dist/release
+          # this zips just like the one in finder
+          ditto -c -k --sequesterRsrc --keepParent "Blender Launcher.app" "Blender_Launcher_${{ github.ref_name }}_macos_arm64.zip"
+          mv "Blender_Launcher_${{ github.ref_name }}_macos_arm64.zip" ../..
+          cd ../..
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./Blender_Launcher_${{  github.ref_name }}_macos_arm64.zip

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -14,11 +14,11 @@ PYTHONOPTIMIZE=2 pyinstaller \
     --name="Blender Launcher" \
     --add-binary="source/resources/certificates/custom.pem:files" \
     --add-data="source/resources/api/blender_launcher_api.json:files" \
-    --add-data="source/resources/api/stable_builds_api.json:files" \
     --distpath="./dist/release" \
     source/main.py
 
 # To create a disk image, uncomment these:
+# illusional: not creating a .dmg because it ballooned the size of the app (to roughly 150MB, .zip is ~35MB).
 # [[ -d ./dist/release/dimg ]] || mkdir ./dist/release/dimg
 # cp -r "./dist/release/Blender Launcher.app" "./dist/release/dimg/Blender Launcher.app"
 # [[ -d ./dist/release/dimg/Applications ]] || ln -s "/Applications" "./dist/release/dimg/Applications"


### PR DESCRIPTION
Prompted by https://github.com/Victor-IX/Blender-Launcher-V2/issues/153#issuecomment-2451078857
Very similar to the windows_release action.

A few notes:
- Until #160 is actioned, I've added a sed hack to expand the pyqt range to `>=`
- I've left building a dmg commented out (and deployed as zip) as it ballooned the size of the app to roughly 150MB, .zip is ~35MB.

Successful action run: https://github.com/illusional/Blender-Launcher-V2/actions/runs/11655072512/job/32449336187
Example of release: https://github.com/illusional/Blender-Launcher-V2/releases/tag/v2.2.99999999

Let me know what you think @Victor-IX / @zeptofine!