### PR TITLE
Settings fix

### DIFF
--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -22,13 +22,15 @@ ISO_EPOCH = EPOCH.isoformat()
 tabs = {
     "Library": 0,
     "Downloads": 1,
-    "User": 2,
+    "Favorites": 2,
 }
 
 library_pages = {
     "Stable Releases": 0,
     "Daily Builds": 1,
     "Experimental Branches": 2,
+    "Bforartists": 3,
+    "Custom": 4,
 }
 
 
@@ -36,6 +38,7 @@ downloads_pages = {
     "Stable Releases": 0,
     "Daily Builds": 1,
     "Experimental Branches": 2,
+    "Bforartists": 3,
 }
 
 

--- a/source/widgets/settings_window/appearance_tab.py
+++ b/source/widgets/settings_window/appearance_tab.py
@@ -6,7 +6,6 @@ from modules.settings import (
     get_enable_download_notifications,
     get_enable_high_dpi_scaling,
     get_enable_new_builds_notifications,
-    get_sync_library_and_downloads_pages,
     get_use_system_titlebar,
     library_pages,
     set_default_downloads_page,
@@ -110,15 +109,7 @@ class AppearanceTabWidget(SettingsFormWidget):
         )
         self.DefaultTabComboBox.setCurrentIndex(get_default_tab())
         self.DefaultTabComboBox.activated[str].connect(self.change_default_tab)
-        # Sync Library and Downloads pages
-        self.SyncLibraryAndDownloadsPages = QCheckBox()
-        self.SyncLibraryAndDownloadsPages.setText("Sync Library && Downloads Pages")
-        self.SyncLibraryAndDownloadsPages.setToolTip(
-            "Sync the selected Library tab with the corresponding Downloads tab\
-            \nDEFAULT: True"
-        )
-        self.SyncLibraryAndDownloadsPages.clicked.connect(self.toggle_sync_library_and_downloads_pages)
-        self.SyncLibraryAndDownloadsPages.setChecked(get_sync_library_and_downloads_pages())
+
         # Default Library Page
         self.DefaultLibraryPageComboBox = QComboBox()
         self.DefaultLibraryPageComboBox.addItems(library_pages.keys())
@@ -140,7 +131,6 @@ class AppearanceTabWidget(SettingsFormWidget):
 
         self.tabs_layout = QFormLayout()
         self.tabs_layout.addRow(QLabel("Default Tab", self), self.DefaultTabComboBox)
-        self.tabs_layout.addRow(self.SyncLibraryAndDownloadsPages)
         self.tabs_layout.addRow(QLabel("Default Library Page", self), self.DefaultLibraryPageComboBox)
         self.tabs_layout.addRow(QLabel("Default Downloads Page", self), self.DefaultDownloadsPageComboBox)
         self.tabs_settings.setLayout(self.tabs_layout)
@@ -160,31 +150,11 @@ class AppearanceTabWidget(SettingsFormWidget):
     def change_default_tab(self, tab):
         set_default_tab(tab)
 
-    def toggle_sync_library_and_downloads_pages(self, is_checked):
-        set_sync_library_and_downloads_pages(is_checked)
-        self.parent.toggle_sync_library_and_downloads_pages(is_checked)
-
-        if is_checked:
-            index = self.DefaultLibraryPageComboBox.currentIndex()
-            self.DefaultDownloadsPageComboBox.setCurrentIndex(index)
-            text = self.DefaultLibraryPageComboBox.currentText()
-            set_default_downloads_page(text)
-
     def change_default_library_page(self, page):
         set_default_library_page(page)
 
-        if get_sync_library_and_downloads_pages():
-            index = self.DefaultLibraryPageComboBox.currentIndex()
-            self.DefaultDownloadsPageComboBox.setCurrentIndex(index)
-            set_default_downloads_page(page)
-
     def change_default_downloads_page(self, page):
         set_default_downloads_page(page)
-
-        if get_sync_library_and_downloads_pages():
-            index = self.DefaultDownloadsPageComboBox.currentIndex()
-            self.DefaultLibraryPageComboBox.setCurrentIndex(index)
-            set_default_library_page(page)
 
     def toggle_enable_download_notifications(self, is_checked):
         set_enable_download_notifications(is_checked)

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -331,7 +331,7 @@ class BlenderLauncher(BaseWindow):
         self.DownloadsToolBox = BaseToolBoxWidget(self)
         self.UserToolBox = BaseToolBoxWidget(self)
 
-        self.toggle_sync_library_and_downloads_pages(get_sync_library_and_downloads_pages())
+        self.toggle_library_and_downloads_pages()
 
         self.LibraryTabLayout.addWidget(self.LibraryToolBox)
         self.DownloadsTabLayout.addWidget(self.DownloadsToolBox)
@@ -554,16 +554,12 @@ class BlenderLauncher(BaseWindow):
         url = f"https://github.com/Victor-IX/Blender-Launcher-V2/releases/tag/v{self.version!s}"
         webbrowser.open(url)
 
-    def toggle_sync_library_and_downloads_pages(self, is_sync):
-        if is_sync:
-            self.LibraryToolBox.tab_changed.connect(self.DownloadsToolBox.setCurrentIndex)
-            self.DownloadsToolBox.tab_changed.connect(self.LibraryToolBox.setCurrentIndex)
-        else:
-            if self.isSignalConnected(self.LibraryToolBox, "tab_changed()"):
-                self.LibraryToolBox.tab_changed.disconnect()
+    def toggle_library_and_downloads_pages(self):
+        if self.isSignalConnected(self.LibraryToolBox, "tab_changed()"):
+            self.LibraryToolBox.tab_changed.disconnect()
 
-            if self.isSignalConnected(self.DownloadsToolBox, "tab_changed()"):
-                self.DownloadsToolBox.tab_changed.disconnect()
+        if self.isSignalConnected(self.DownloadsToolBox, "tab_changed()"):
+            self.DownloadsToolBox.tab_changed.disconnect()
 
     def isSignalConnected(self, obj, name):
         index = obj.metaObject().indexOfMethod(name)


### PR DESCRIPTION
- Add missing tabs in the default tab and page option dropdown
- Remove sync tab settings as this doesn't make sense to have it anymore as the tabs are not the same between lib and download 
#188 