### PR TITLE
Linux - Use XDG path for .desktop files

### DIFF
--- a/source/modules/shortcut.py
+++ b/source/modules/shortcut.py
@@ -42,10 +42,9 @@ def create_shortcut(folder, name):
     elif platform == "Linux":
         _exec = library_folder / folder / "blender"
         icon = library_folder / folder / "blender.svg"
-        # TODO: This path will probably nor work on a non-English system
-        desktop = Path.home() / "Desktop"
+        path = get_default_shortcut_destination().parent
         filename = name.replace(" ", "-")
-        dist = desktop / (filename + ".desktop")
+        dist = path / (filename + ".desktop")
 
         kws = (
             "3d;cg;modeling;animation;painting;"

--- a/source/modules/shortcut.py
+++ b/source/modules/shortcut.py
@@ -191,7 +191,7 @@ def get_default_shortcut_destination(shortcut_name):
     folder = get_default_shortcut_folder()
 
     if platform == "Windows":
-        return Path(folder / shortcut_name + ".lnk")
+        return Path(folder / (shortcut_name + ".lnk"))
 
     return Path(folder / (shortcut_name.replace(" ", "-") + ".desktop"))
 

--- a/source/modules/shortcut.py
+++ b/source/modules/shortcut.py
@@ -11,7 +11,7 @@ from modules.settings import get_library_folder
 
 
 # TODO: Remove this duplicate code generate_program_shortcut()
-def create_shortcut(folder, name):
+def generate_blender_shortcut(folder, name, destination: Path):
     platform = get_platform()
     library_folder = Path(get_library_folder())
 
@@ -21,8 +21,6 @@ def create_shortcut(folder, name):
 
         targetpath = library_folder / folder / "blender.exe"
         workingdir = library_folder / folder
-        desktop = shell.SHGetFolderPath(0, shellcon.CSIDL_DESKTOP, None, 0)
-        dist = Path(desktop) / (name + ".lnk")
 
         if getattr(sys, "frozen", False):
             icon = sys._MEIPASS + "/files/winblender.ico"  # noqa: SLF001
@@ -33,7 +31,7 @@ def create_shortcut(folder, name):
         copyfile(icon, icon_location.as_posix())
 
         _WSHELL = win32com.client.Dispatch("Wscript.Shell")
-        wscript = _WSHELL.CreateShortCut(dist.as_posix())
+        wscript = _WSHELL.CreateShortCut(destination.as_posix())
         wscript.Targetpath = targetpath.as_posix()
         wscript.WorkingDirectory = workingdir.as_posix()
         wscript.WindowStyle = 0
@@ -42,9 +40,6 @@ def create_shortcut(folder, name):
     elif platform == "Linux":
         _exec = library_folder / folder / "blender"
         icon = library_folder / folder / "blender.svg"
-        path = get_default_shortcut_destination().parent
-        filename = name.replace(" ", "-")
-        dist = path / (filename + ".desktop")
 
         kws = (
             "3d;cg;modeling;animation;painting;"
@@ -67,11 +62,10 @@ def create_shortcut(folder, name):
                 "Exec={} %f".format(_exec.as_posix().replace(" ", r"\ ")),
             ]
         )
-        with open(dist, "w", encoding="utf-8") as file:
+        with open(destination, "w", encoding="utf-8") as file:
             file.write(desktop_entry)
 
-        os.chmod(dist, 0o744)
-
+        os.chmod(destination, 0o744)
 
 def association_is_registered() -> bool:
     assert sys.platform == "win32"
@@ -186,13 +180,29 @@ def get_shortcut_type() -> str:
     }.get(get_platform(), "Shortcut")
 
 
-def get_default_shortcut_destination():
-    return {
-        "Windows": Path(
-            Path.home(), "AppData", "Roaming", "Microsoft", "Windows", "Start Menu", "Programs", "Blender Launcher V2"
-        ),
-        "Linux": Path(Path.home(), ".local", "share", "applications", "BLV2.desktop"),
-    }.get(get_platform(), Path.home() / "BLV2.desktop")
+def get_default_program_shortcut_destination():
+    return get_default_shortcut_destination("Blender Launcher V2")
+
+
+def get_default_shortcut_destination(shortcut_name):
+    platform = get_platform()
+    folder = get_default_shortcut_folder()
+
+    if platform == "Windows":
+        return Path(folder / shortcut_name + ".lnk")
+
+    return Path(folder / (shortcut_name.replace(" ", "-") + ".desktop"))
+
+
+def get_default_shortcut_folder():
+    platform = get_platform()
+
+    if platform == "Windows":
+        return Path(Path.home() / "AppData" / "Roaming" / "Microsoft" / "Windows" / "Start Menu" / "Programs")
+    elif platform == "Linux":
+        return Path(Path.home() / ".local" / "share" / "applications")
+
+    return Path.home()
 
 
 def generate_program_shortcut(destination: Path, exe=sys.executable):

--- a/source/modules/shortcut.py
+++ b/source/modules/shortcut.py
@@ -181,10 +181,12 @@ def get_shortcut_type() -> str:
 
 
 def get_default_program_shortcut_destination():
+    """Returns the default folder to where a shortcut to Blender Launcher should be saved."""
     return get_default_shortcut_destination("Blender Launcher V2")
 
 
 def get_default_shortcut_destination(shortcut_name):
+    """Returns the default folder to where a shortcut with name 'shortcut_name' should be saved."""
     platform = get_platform()
     folder = get_default_shortcut_folder()
 
@@ -195,6 +197,7 @@ def get_default_shortcut_destination(shortcut_name):
 
 
 def get_default_shortcut_folder():
+    """Returns the default folder to where shortcuts should be saved."""
     platform = get_platform()
 
     if platform == "Windows":

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -26,7 +26,7 @@ from modules.settings import (
     get_mark_as_favorite,
     set_favorite_path,
 )
-from modules.shortcut import create_shortcut
+from modules.shortcut import generate_blender_shortcut, get_default_shortcut_destination
 from PySide6 import QtCore
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtGui import (
@@ -50,6 +50,7 @@ from widgets.elided_text_label import ElidedTextLabel
 from widgets.left_icon_button_widget import LeftIconButtonWidget
 from windows.custom_build_dialog_window import CustomBuildDialogWindow
 from windows.popup_window import PopupIcon, PopupWindow
+from windows.file_dialog_window import FileDialogWindow
 
 if TYPE_CHECKING:
     from windows.main_window import BlenderLauncher
@@ -776,7 +777,12 @@ class LibraryWidget(BaseBuildWidget):
             self.build_info.branch.replace("-", " ").title(),
         )
 
-        create_shortcut(self.link, name)
+        destination = get_default_shortcut_destination(name)
+        file_place = FileDialogWindow().get_save_filename(
+            parent=self, title="Choose destination", directory=str(destination)
+        )
+        if file_place[0]:
+            generate_blender_shortcut(self.link, name, Path(file_place[0]))
 
     @Slot()
     def create_symlink(self):

--- a/source/widgets/onboarding_setup/wizard_pages.py
+++ b/source/widgets/onboarding_setup/wizard_pages.py
@@ -26,7 +26,7 @@ from modules.settings import (
     set_show_tray_icon,
     set_use_system_titlebar,
 )
-from modules.shortcut import generate_program_shortcut, get_default_program_shortcut_destination, get_default_shortcut_destination, register_windows_filetypes
+from modules.shortcut import generate_program_shortcut, get_default_program_shortcut_destination, register_windows_filetypes
 from PySide6.QtWidgets import (
     QCheckBox,
     QHBoxLayout,

--- a/source/widgets/onboarding_setup/wizard_pages.py
+++ b/source/widgets/onboarding_setup/wizard_pages.py
@@ -26,7 +26,7 @@ from modules.settings import (
     set_show_tray_icon,
     set_use_system_titlebar,
 )
-from modules.shortcut import generate_program_shortcut, get_default_program_shortcut_destination, register_windows_filetypes
+from modules.shortcut import generate_program_shortcut, get_default_shortcut_folder, get_default_program_shortcut_destination, register_windows_filetypes
 from PySide6.QtWidgets import (
     QCheckBox,
     QHBoxLayout,
@@ -234,7 +234,7 @@ class ShortcutsPage(BasicOnboardingPage):
         if self.platform == "Linux":
             self.select = FolderSelector(
                 parent,
-                default_folder=get_default_program_shortcut_destination(),
+                default_folder=get_default_shortcut_folder(),
                 check_relatives=False,
             )
             self.select.setEnabled(False)

--- a/source/widgets/onboarding_setup/wizard_pages.py
+++ b/source/widgets/onboarding_setup/wizard_pages.py
@@ -26,7 +26,7 @@ from modules.settings import (
     set_show_tray_icon,
     set_use_system_titlebar,
 )
-from modules.shortcut import generate_program_shortcut, get_default_shortcut_destination, register_windows_filetypes
+from modules.shortcut import generate_program_shortcut, get_default_program_shortcut_destination, get_default_shortcut_destination, register_windows_filetypes
 from PySide6.QtWidgets import (
     QCheckBox,
     QHBoxLayout,
@@ -234,7 +234,7 @@ class ShortcutsPage(BasicOnboardingPage):
         if self.platform == "Linux":
             self.select = FolderSelector(
                 parent,
-                default_folder=get_default_shortcut_destination().parent,
+                default_folder=get_default_program_shortcut_destination(),
                 check_relatives=False,
             )
             self.select.setEnabled(False)
@@ -259,7 +259,7 @@ class ShortcutsPage(BasicOnboardingPage):
                 assert self.select.path is not None
 
                 if self.select.path.is_dir():
-                    pth = self.select.path / get_default_shortcut_destination().name
+                    pth = self.select.path / get_default_program_shortcut_destination().name
                 else:
                     pth = self.select.path
 
@@ -274,7 +274,7 @@ class ShortcutsPage(BasicOnboardingPage):
 
             if self.addtostart.isChecked():
                 generate_program_shortcut(
-                    get_default_shortcut_destination(),
+                    get_default_program_shortcut_destination(),
                     exe=str(self.prop_settings.exe_location),
                 )
             if self.addtodesk.isChecked():

--- a/source/widgets/onboarding_setup/wizard_pages.py
+++ b/source/widgets/onboarding_setup/wizard_pages.py
@@ -194,7 +194,7 @@ To reverse this after installation, there is a labeled panel in the Settings gen
 Hover over this text to see which registry keys will be changed and for what reason.
 """
 
-ASSOC_LINUX_EXPLAIN = """In order to launch blendilfes with Blender Launcher on Linux, we will generate a .desktop file at the requested location. \
+ASSOC_LINUX_EXPLAIN = """In order to launch blendfiles with Blender Launcher on Linux, we will generate a .desktop file at the requested location. \
 It contains mimetype data which tells the desktop environment (DE) what files the program expects to handle, and as a side effect the program is also visible in application launchers.
 
 Our default location is typically searched by DEs for application entries.

--- a/source/widgets/settings_window/general_tab.py
+++ b/source/widgets/settings_window/general_tab.py
@@ -28,7 +28,7 @@ from modules.settings import (
     set_default_delete_action,
     user_config,
 )
-from modules.shortcut import generate_program_shortcut, get_default_shortcut_destination, get_shortcut_type
+from modules.shortcut import generate_program_shortcut, get_default_program_shortcut_destination, get_shortcut_type
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -276,7 +276,7 @@ class GeneralTabWidget(SettingsFormWidget):
         # Most getters should get the settings from the new position, so a restart should not be required
 
     def create_shortcut(self):
-        destination = get_default_shortcut_destination()
+        destination = get_default_program_shortcut_destination()
         file_place = FileDialogWindow().get_save_filename(
             parent=self, title="Choose destination", directory=str(destination)
         )


### PR DESCRIPTION
As per #233.

- When clicking "Create Shortcut", a location for the shortcut can be specified, defaulting to the XDG folder for .desktop files (```~/.local/share/applications```), and ```Start Menu/Programs``` on Windows, in line with where the Blender Launcher shortcut is put.

- Split ```get_default_shortcut_destination``` into 3 methods, to make it more usable for sharing between Blender Launcher- and Blender shortcuts.

- Small typo in the first-run wizard.