### PR TITLE
Command line arguments documentation

### DIFF
--- a/docs/mkdocs/development.md
+++ b/docs/mkdocs/development.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 - Linux or Windows x64
-- Python >=3.9, <3.11
+- Python >=3.10, <3.14
 
 
 !!! info "Note"

--- a/docs/mkdocs/settings.md
+++ b/docs/mkdocs/settings.md
@@ -241,4 +241,3 @@ Actions that will be performed on newly added builds to Library tab right after 
     ```
     env __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia nohup %path to blender executable% %startup arguments%
     ```
-```

--- a/docs/mkdocs/settings.md
+++ b/docs/mkdocs/settings.md
@@ -241,3 +241,61 @@ Actions that will be performed on newly added builds to Library tab right after 
     ```
     env __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia nohup %path to blender executable% %startup arguments%
     ```
+
+### Command Line Arguments
+
+Blender Launcher can be launched from the command line with the following options.
+
+```
+usage: Blender Launcher.exe [-h] [-d] [-set-library-folder SET_LIBRARY_FOLDER]
+                            [-force-first-time] [--offline] [--build-cache]
+                            [--instanced]
+                            {update,launch,register,unregister} ...
+
+Blender Launcher (2.4.3)
+
+positional arguments:
+  {update,launch,register,unregister}
+    update              Update the application to a new version. Run 'update --help' to see available options.
+    launch              Launch a specific version of Blender. If not file or version is specified, Quick launch is
+                        chosen. Run 'launch --help' to see available options.
+    register            Registers the program to read .blend builds. Adds Blender Launcher to the Open With window.
+                        (WIN ONLY)
+    unregister          Undoes the changes that `register` makes. (WIN ONLY)
+
+options:
+  -h, --help            show this help message and exit
+  -d, -debug, --debug   Enable debug logging.
+  -set-library-folder SET_LIBRARY_FOLDER
+                        Set library folder
+  -force-first-time     Force the first time setup
+  --offline, -offline   Run the application offline. (Disables scraper threads and update checks)
+  --build-cache         Launch the app and cache all the available builds.
+  --instanced, -instanced
+                        Do not check for existing instance.
+```
+
+`launch` command line arguments:
+```
+usage: Blender Launcher.exe launch [-h] [-f FILE | -ol] [-v VERSION] [-c]
+
+options:
+  -h, --help            show this help message and exit
+  -f FILE, --file FILE  Path to a specific Blender file to launch.
+  -ol, --open-last      Open the last file in the specified blender build
+  -v VERSION, --version VERSION
+                        Version to launch. <major_num>.<minor>.<patch>[-<branch>][+<build_hash>][@<commit time>]
+  -c, --cli             Launch Blender from CLI. does not open any QT frontend. WARNING: LIKELY DOES NOT WORK IN
+                        WINDOWS BUNDLED EXECUTABLE
+```
+
+`update` command line arguments:
+```
+usage: Blender Launcher.exe update [-h] [version]
+
+positional arguments:
+  version     Version to update to.
+
+options:
+  -h, --help  show this help message and exit
+```

--- a/source/main.py
+++ b/source/main.py
@@ -100,7 +100,7 @@ def main():
 
     update_parser = subparsers.add_parser(
         "update",
-        help="Update the application to a new version.",
+        help="Update the application to a new version. Run 'update --help' to see available options.",
         add_help=False,
     )
     add_help(update_parser)
@@ -129,7 +129,10 @@ def main():
 
     launch_parser = subparsers.add_parser(
         "launch",
-        help="Launch a specific version of Blender. If not file or version is specified, Quick launch is chosen.",
+        help=(
+            "Launch a specific version of Blender. If not file or version is specified, "
+            "Quick launch is chosen. Run 'launch --help' to see available options."
+        ),
         add_help=False,
     )
     add_help(launch_parser)


### PR DESCRIPTION
1. Fix required Python version in the documentation. Unrelated to theme of this PR, just a small fix.

2. Add command line arguments to the documentation

3. Mention `launch --help` and `update --help` in their description to make them more descriable as it's easy to confuse them with just positional arguments that don't have their own suboptions.