### PR TITLE
'launch' option to support providing arguments to Blender

### DIFF
--- a/docs/mkdocs/settings.md
+++ b/docs/mkdocs/settings.md
@@ -279,6 +279,10 @@ options:
 ```
 usage: Blender Launcher.exe launch [-h] [-f FILE | -ol] [-v VERSION] [-c]
 
+positional arguments:
+  blender_args          Additional arguments to pass to Blender, should be provided after double dash.
+                        E.g. 'launch -- --background',
+
 options:
   -h, --help            show this help message and exit
   -f FILE, --file FILE  Path to a specific Blender file to launch.

--- a/source/modules/cli_launching.py
+++ b/source/modules/cli_launching.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import NoReturn
+from typing import NoReturn, Sequence
 
 from modules.blendfile_reader import read_blendfile_header
 from modules.build_info import BuildInfo, LaunchMode, LaunchOpenLast, LaunchWithBlendFile, get_args
@@ -18,7 +18,10 @@ logger = logging.getLogger()
 
 
 def cli_launch(
-    file: Path | None = None, version_query: VersionSearchQuery | None = None, open_last: bool = False
+    file: Path | None = None,
+    version_query: VersionSearchQuery | None = None,
+    open_last: bool = False,
+    blender_args: Sequence[str] = (),
 ) -> NoReturn:
     # Search for builds
     logger.info("Searching for all builds")
@@ -103,6 +106,10 @@ def cli_launch(
         build_info = basics[build]
 
     args = get_args(build_info, launch_mode=launch_mode, linux_nohup=False)
+    if isinstance(args, list):
+        args.extend(blender_args)
+    else:
+        args += f" {' '.join(blender_args)}"
     logger.info(f"Launching build: {build}")
     logger.info(f"With args: {args}")
     proc = subprocess.Popen(args, shell=True)


### PR DESCRIPTION
Was trying to find a way to manage multiple instances of Blender as I constantly need to switch between them for testing and I really like the Python launcher on windows. When you can call `py` by default works exactly as `python` and `py -3.12` does exactly the same but autodetect Python 3.12 and automatically passing command line arguments to it.

Here I was aiming for a similar feature by adding an option Blender arguments in 'launch' option after double-dash.
```
py source\main.py launch --version 3.6.19 --cli -- --background
```

Which is a bit verbose for daily use but with a simple script like https://github.com/Andrej730/blauncher it allows:
```
blauncher -4.4 --background
```

Sorry for redundant commits in this PR, will rebase if #240 will get merged.
Will be testing this for a few days just to be sure, so I'll keep it as a draft for now.

@Victor-IX any thoughts?