### PR TITLE
Fix test after c28f5a7

### DIFF
--- a/source/modules/version_matcher.py
+++ b/source/modules/version_matcher.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":  # Test BInfoMatcher
 
     def test_binfo_matcher():
         # find the latest minor builds with any patch number
-        results = matcher.match(VersionSearchQuery("^", "^", "*"))
+        results = matcher.match(VersionSearchQuery("^", "^", "*", commit_time="*"))
         assert results == (
             BasicBuildInfo(Version.parse("4.3.0"), "daily", "", datetime.datetime(2024, 7, 30, tzinfo=utc)),
             BasicBuildInfo(Version.parse("4.3.0"), "daily", "", datetime.datetime(2024, 7, 28, tzinfo=utc)),


### PR DESCRIPTION
`commit_time` is no longer `None` by default, so set it back to "*" for tests