### PR TITLE
Support pytest and add simple makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+SHELL := sh
+
+.PHONY:
+run:
+	python source/main.py
+
+.PHONY:
+test:
+	pytest source/modules/version_matcher.py

--- a/docs/mkdocs/development.md
+++ b/docs/mkdocs/development.md
@@ -50,7 +50,7 @@
     ===+ "All packages including development tools"
 
         ```bash
-        pip install -e ".[docs,ruff]"
+        pip install -e ".[docs,ruff,pytest]"
         ```
 
 ## Running Blender Launcher

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ license = { text = "GPL3" }
 [project.optional-dependencies]
 docs = ["mkdocs", "mkdocs-material>=9.5.10"]
 ruff = ["ruff>=0.3.5"]
+test = ["pytest"]
 
 [build-system]
 build-backend = "pdm.backend"

--- a/source/modules/version_matcher.py
+++ b/source/modules/version_matcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import contextlib
 import datetime
 import re
@@ -257,7 +258,7 @@ class BInfoMatcher:
         return tuple(versions)
 
 
-if __name__ == "__main__":  # Test BInfoMatcher
+if __name__ == "__main__" or "PYTEST_VERSION" in os.environ:  # Test BInfoMatcher
     builds = (
         BasicBuildInfo(Version.parse("1.2.3"), "stable", "", datetime.datetime(2020, 5, 4, tzinfo=utc)),
         BasicBuildInfo(Version.parse("1.2.2"), "stable", "", datetime.datetime(2020, 4, 2, tzinfo=utc)),


### PR DESCRIPTION
Changes:
- support running pytest for rich assert messages
- Add simple makefile for running Blender Launcher and starting tests (perhaps there will be more in the future)