### PR TITLE
Support double dash Blender argument

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -205,13 +205,17 @@ def main():
         start_update(app, args.instanced, args.version)
 
     if args.command == "launch":
+        blender_args: list[str] = args.blender_args.copy()
+        # Skip only first `--`, as it also can be a valid argument to pass to Blender.
+        if "--" in blender_args:
+            blender_args.remove("--")
         start_launch(
             app,
             args.file,
             args.version,
             args.open_last,
             cli=args.cli,
-            blender_args=[arg for arg in args.blender_args if arg != "--"],
+            blender_args=blender_args,
         )
 
     if args.command == "register":


### PR DESCRIPTION
Found an issue with the commit submitted by me before (2e3c191), it's skipping all `--` arguments though it's still possible to provide additional Blender arguments. 

E.g. it's possible to launch  blender with something like `blender --factory-startup --background --python-expr "import sys; print(sys.argv") -- argv1 argv2` and the output will be similar to:
```
['L:/Projects/Github/Blender-Launcher-V2/downloads/stable/blender-4.4.3-stable.802179c51ccc/blender.exe', '--factory-startup', '--background', '--python-expr', 'import sys; print(sys.argv)', '--', 'argv1', 'argv2']
```

But without this fix, `--` will be skipped leading to incorrect results.