### PR TITLE
Support sorting builds by label

### DIFF
--- a/source/items/base_list_widget_item.py
+++ b/source/items/base_list_widget_item.py
@@ -17,12 +17,14 @@ class BaseListWidgetItem(QListWidgetItem):
         self.listWidget: Callable[[], BaseListWidget | None]
 
     def __lt__(self, other):
-        soring_type = self.listWidget().parent.sorting_type
+        sorting_type = self.listWidget().parent.sorting_type
 
-        if soring_type.name == "DATETIME":
+        if sorting_type.name == "DATETIME":
             return self.compare_datetime(other)
-        if soring_type.name == "VERSION":
+        if sorting_type.name == "VERSION":
             return self.compare_version(other)
+        if sorting_type.name == "LABEL":
+            return self.compare_label(other)
         return False
 
     def compare_datetime(self, other):
@@ -56,3 +58,22 @@ class BaseListWidgetItem(QListWidgetItem):
             return self.compare_datetime(other)
 
         return this_version > other_version
+
+    def compare_label(self, other):
+        list_widget = self.listWidget()
+
+        this_widget = list_widget.itemWidget(self)
+        other_widget = list_widget.itemWidget(other)
+
+        if (
+            this_widget is None
+            or other_widget is None
+            or this_widget.build_info is None
+            or other_widget.build_info is None
+        ):
+            return False
+
+        this_label = this_widget.build_info.display_label
+        other_label = other_widget.build_info.display_label
+
+        return this_label < other_label

--- a/source/widgets/base_page_widget.py
+++ b/source/widgets/base_page_widget.py
@@ -16,6 +16,7 @@ from widgets.base_list_widget import BaseListWidget
 class SortingType(Enum):
     DATETIME = 1
     VERSION = 2
+    LABEL = 3
 
 
 class BasePageWidget(QWidget):
@@ -97,8 +98,10 @@ class BasePageWidget(QWidget):
         self.subversionLabel.setProperty("ListHeader", True)
         self.subversionLabel.setCheckable(True)
         self.subversionLabel.clicked.connect(lambda: self.set_sorting_type(SortingType.VERSION))
-        self.branchLabel = QLabel("Branch")
-        self.branchLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.branchLabel = QPushButton("Branch")
+        self.branchLabel.setProperty("ListHeader", True)
+        self.branchLabel.setCheckable(True)
+        self.branchLabel.clicked.connect(lambda: self.set_sorting_type(SortingType.LABEL))
         self.commitTimeLabel = QPushButton(time_label)
         self.commitTimeLabel.setFixedWidth(118)
         self.commitTimeLabel.setProperty("ListHeader", True)
@@ -138,5 +141,6 @@ class BasePageWidget(QWidget):
 
         self.commitTimeLabel.setChecked(sorting_type == SortingType.DATETIME)
         self.subversionLabel.setChecked(sorting_type == SortingType.VERSION)
+        self.branchLabel.setChecked(sorting_type == SortingType.LABEL)
 
         set_list_sorting_type(self.name, sorting_type)


### PR DESCRIPTION
Sorting by label is especially helpful for experimental builds currently so that one can more easily find a specific PR. Since it's already possible to sort by the other columns, this seems to be quite straight forward UI wise.

https://github.com/user-attachments/assets/8a28b5fc-b6dc-46c9-94fc-ae904a4d40e8

Finding the right PR is still somewhat tricky without a search or without seeing the actual names of the PRs (instead of just the identifiers), but that can also be improved separately.
