### PR TITLE
fix winget action vedantmgoyal9/winget-releaser@main

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -21,7 +21,7 @@ jobs:
           TAG_NAME: ${{ inputs.tag_name || github.event.release.tag_name }}
         run: echo "WINGET_TAG_NAME=$(echo ${TAG_NAME#v})" >> $GITHUB_ENV
       - name: Submit package to Windows Package Manager Community Repository
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: VictorIX.BlenderLauncher
           installers-regex: '^Blender_Launcher_v[\d.]+_Windows_x64\.zip$'


### PR DESCRIPTION
Latest winget package version is 2.4.6 when github release is 2.4.7, probably because of this typo

Could not interpret logs but here they are in case it's useful. 

https://github.com/Victor-IX/Blender-Launcher-V2/actions/runs/16665298222/job/47170311610