### PR TITLE
Fix Bforartists installed detection on startup

### DIFF
--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -131,7 +131,18 @@ class BuildInfo:
             return False
         if (self.build_hash is not None) and (other.build_hash is not None):
             return self.build_hash == other.build_hash
-        return self.subversion == other.subversion
+
+        # Compare by semver major.minor.patch (ignore prerelease differences)
+        # This allows "4.5.2" to match "4.5.2-window" for Bforartists builds
+        try:
+            self_ver = parse_blender_ver(self.subversion)
+            other_ver = parse_blender_ver(other.subversion)
+            return (self_ver.major == other_ver.major and
+                    self_ver.minor == other_ver.minor and
+                    self_ver.patch == other_ver.patch)
+        except (ValueError, Exception):
+            # Fall back to string comparison if parsing fails
+            return self.subversion == other.subversion
 
     @property
     def semversion(self):
@@ -286,7 +297,7 @@ def fill_blender_info(exe: Path, info: BuildInfo | None = None) -> tuple[datetim
 
     if info is not None and info.subversion is not None:
         subversion = info.subversion
-    elif s := re.search("Blender (.*)", version):
+    elif s := re.search(r"(?:Blender|Bforartists) (.*)", version):
         subversion = s[1].rstrip()
     else:
         s = version.splitlines()[0].strip()

--- a/source/threads/library_drawer.py
+++ b/source/threads/library_drawer.py
@@ -36,14 +36,26 @@ def get_blender_builds(folders: Iterable[str | Path]) -> Iterable[tuple[Path, bo
         "macOS": "Blender/Blender.app/Contents/MacOS/Blender",
     }.get(platform, "blender")
 
+    # Bforartists uses different executable names
+    bforartists_exe = {
+        "Windows": "bforartists.exe",
+        "Linux": "bforartists",
+        "macOS": "Bforartists/Bforartists.app/Contents/MacOS/Bforartists",
+    }.get(platform, "bforartists")
+
     for folder in folders:
         path = library_folder / folder
         if path.is_dir():
             for build in path.iterdir():
                 if build.is_dir():
+                    # Check for .blinfo file or executable (blender.exe or bforartists.exe)
+                    has_blinfo = (folder / build / ".blinfo").is_file()
+                    has_blender_exe = (path / build / blender_exe).is_file()
+                    has_bforartists_exe = (path / build / bforartists_exe).is_file()
+
                     yield (
                         folder / build,
-                        ((folder / build / ".blinfo").is_file() or (path / build / blender_exe).is_file()),
+                        has_blinfo or has_blender_exe or has_bforartists_exe,
                     )
 
 


### PR DESCRIPTION
- Recognize bforartists.exe when scanning library folder
- Compare BuildInfo by major.minor.patch to match "4.5.2" with "4.5.2-window"
- Support "Bforartists" prefix in version string parsing