### PR TITLE
Add application/x-apple-diskimage to VALID_ARCHIVE_TYPES

### DIFF
--- a/source/threads/downloader.py
+++ b/source/threads/downloader.py
@@ -20,6 +20,7 @@ logger = logging.getLogger()
 # Valid MIME types for archive files
 VALID_ARCHIVE_TYPES = [
     "application/zip",
+    "application/x-apple-diskimage",
     "application/x-zip-compressed",
     "application/octet-stream",
     "application/x-tar",


### PR DESCRIPTION
fixed #295 

Regarding content-type, the release version for Mac uses `application/x-dmg`, while the beta version uses `application/x-apple-diskimage`.