### PR TITLE
Fix time column width clipping on macOS

### DIFF
--- a/source/widgets/datetime_widget.py
+++ b/source/widgets/datetime_widget.py
@@ -31,9 +31,8 @@ class DateTimeWidget(QPushButton):
         self.datetimeLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.font_metrics = self.datetimeLabel.fontMetrics()
 
-        self.setMinimumWidth(
-            self.font_metrics.horizontalAdvance(f"{self.left_arrow}{self.datetimeStr}{self.right_arrow}")
-        )
+        # Set fixed width to match header width (118px from base_page_widget.py)
+        self.setFixedWidth(118)
 
         if self.build_hash is not None:
             self.LeftArrowLabel = QLabel(self.left_arrow)
@@ -43,19 +42,19 @@ class DateTimeWidget(QPushButton):
 
             self.BuildHashLabel = QLabel(self.build_hash)
             self.BuildHashLabel.hide()
+            self.BuildHashLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
             self.layout.addWidget(self.LeftArrowLabel)
-            self.layout.addStretch()
-            self.layout.addWidget(self.datetimeLabel)
-            self.layout.addWidget(self.BuildHashLabel)
-            self.layout.addStretch()
+            self.layout.addWidget(self.datetimeLabel, stretch=1)
+            self.layout.addWidget(self.BuildHashLabel, stretch=1)
             self.layout.addWidget(self.RightArrowLabel)
 
             self.setCursor(Qt.CursorShape.PointingHandCursor)
             self.setToolTip("Press to show build hash number")
             self.clicked.connect(self.toggle_visibility)
         else:
-            self.layout.addWidget(self.datetimeLabel)
+            self.datetimeLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.layout.addWidget(self.datetimeLabel, stretch=1)
 
     def toggle_visibility(self):
         self.datetimeLabel.setVisible(not self.datetimeLabel.isVisible())


### PR DESCRIPTION
## Problem
On macOS, the commit time values in the library and download lists were being clipped on the left side, making them difficult to read. This occurred because:

## Solution
- Changed from `setMinimumWidth()` to `setFixedWidth(118)` to match the header width
  - **Rationale for 118px**: This value is defined in `base_page_widget.py:106` where the commit time
header column (`commitTimeLabel`) is set to `setFixedWidth(118)`
- Replaced `addStretch()` calls with `stretch=1` parameter on the labels themselves for proper centering
within the fixed width
- Added explicit center alignment to both datetime and build hash labels


**before**
<img width="686" height="526" alt="スクリーンショット 2025-11-11 23 19 04" src="https://github.com/user-attachments/assets/4eb2cc35-8832-47d1-8bcc-b0c328ae5ec5" />

**fixed**
<img width="686" height="547" alt="スクリーンショット 2025-11-11 23 19 57" src="https://github.com/user-attachments/assets/121ab238-9277-4472-ba60-eb73bd9aedc3" />
