### PR TITLE
Support for Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ dependencies = [
     "send2trash>=1.8.3",
     "webdav4==0.10.0",
     "dateparser==1.2.1",
-    "pyside6-essentials==6.8.1",
+    "pyside6-essentials==6.10.1",
     "markdown>=3.7",
 ]
-requires-python = "<3.14,>=3.10"
+requires-python = "<3.15,>=3.10"
 readme = "README.md"
 license = { text = "GPL3" }
 


### PR DESCRIPTION
pyside6-essentials only supports 3.14 since 6.10.1

See
https://pypi.org/project/PySide6-Essentials/6.10.0/
https://pypi.org/project/PySide6-Essentials/6.10.1/

<img width="292" height="181" alt="image" src="https://github.com/user-attachments/assets/7b3e6245-6c38-4bbd-96fd-7bc0de0477f6" /> 
<img width="299" height="179" alt="image" src="https://github.com/user-attachments/assets/e1cb0f13-2ea0-4964-b54e-b976b7c20d75" />

