### PR TITLE
Fix Bforartists not launching on Windows/Linux

### DIFF
--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -558,6 +558,8 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
                     and (launcher := (library_folder / info.link / "blender-launcher.exe")).exists()
                 ):
                     b3d_exe = launcher
+                elif (bfa_exe := (library_folder / info.link / "bforartists.exe")).exists():
+                    b3d_exe = bfa_exe
                 else:
                     b3d_exe = library_folder / info.link / "blender.exe"
 
@@ -584,6 +586,8 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
         cexe = info.custom_executable
         if cexe:
             b3d_exe = library_folder / info.link / cexe
+        elif (bfa_exe := (library_folder / info.link / "bforartists")).exists():
+            b3d_exe = bfa_exe
         else:
             b3d_exe = library_folder / info.link / "blender"
 

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -610,6 +610,8 @@ class Scraper(QThread):
                 folder = self.bfa_cache[semver]
 
             if folder.modified_date < modified_date:
+                # Clear existing assets and replace with fresh data
+                folder.assets.clear()
                 for release in self.scrape_bfa_release(client, entry["name"], semver):
                     folder.assets.append(release)
                     yield release
@@ -637,12 +639,23 @@ class Scraper(QThread):
             if not isinstance(commit_time, datetime):
                 continue
 
-            # Don't set custom_executable - let it be auto-detected during installation
-            # This ensures consistent behavior with Blender
+            # Set custom_executable for Windows/Linux since Bforartists uses a different
+            # executable name than Blender. On macOS, let it be auto-detected during
+            # installation to handle DMG-extracted .app bundles correctly.
+            platform = get_platform()
+            if platform == "macOS":
+                exe_name = None
+            else:
+                exe_name = {
+                    "Windows": "bforartists.exe",
+                    "Linux": "bforartists",
+                }.get(platform, "bforartists")
+
             yield BuildInfo(
                 get_bfa_nc_https_download_url(ppath),
                 str(semver),
                 None,
                 commit_time.astimezone(),
                 "bforartists",
+                custom_executable=exe_name,
             )


### PR DESCRIPTION
Summary

- Fix a bug where Bforartists builds fail to launch on Windows and Linux
- The launcher was trying to run blender.exe instead of bforartists.exe

Problem

After commit 949ba64 ("Fix macOS executable path detection for DMG-extracted builds"), the custom_executable field was no longer set for Bforartists builds. This caused:

1. New Bforartists downloads to have custom_executable: null in their .blinfo file
2. At launch time, the code falls back to blender.exe (default) which doesn't exist in Bforartists builds
3. Result: Bforartists 5.0.0 and newer versions fail to launch

Fix

- Restore custom_executable setting (bforartists.exe / bforartists) for Windows/Linux in the scraper
- Keep macOS using auto-detection to properly handle DMG-extracted .app bundles
- Add fallback executable detection in get_args() for existing .blinfo files with custom_executable: null
- Clear existing cache assets before updating to prevent duplicate entries
