### PR TITLE
Fix Show Config Folder for bforartists builds

### DIFF
--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -643,7 +643,7 @@ def launch_build(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = Non
 def bfa_version_matcher(bfa_blender_version: Version) -> Version | None:
     versions = read_blender_version_list()
     for i, version in enumerate(versions):
-        if version.match(f"{bfa_blender_version.major}.{bfa_blender_version.minor}"):
+        if version.match(f"{bfa_blender_version.major}.{bfa_blender_version.minor}.{bfa_blender_version.patch}"):
             if i + 1 < len(versions) and i > 0:
                 return versions[i - 1]
             else:

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -681,8 +681,23 @@ class LibraryWidget(BaseBuildWidget):
         version = self.build_info.subversion.rsplit(".", 1)[0]
 
         if version >= "4.2":
-            folder_name = "portable"
-            config_path = self.link / folder_name
+            # Check for portable folder first (standard Blender 4.2+)
+            portable_path = self.link / "portable"
+            if portable_path.is_dir():
+                return portable_path
+            subpaths = ["config", "datafiles", "scripts", "extensions"]
+
+            # Check for version folder (X.Y format) used by bforartists
+            if get_platform() == "Windows" and self.link.is_dir():
+                for item in self.link.iterdir():
+                    if (
+                        item.is_dir()
+                        and re.match(r"^\d+\.\d+$", item.name)
+                        and any((item / subpath).is_dir() for subpath in subpaths)
+                    ):
+                        return item
+
+            return portable_path
         else:
             folder_name = "config"
             config_path = self.link / version / folder_name


### PR DESCRIPTION
fix #318 

## Summary

- Fix `bfa_version_matcher` to use valid SemVer string format (add patch version to `version.match()`)
- Add detection for Bforartists version folder (X.Y format) in portable config path on Windows
- Extend portable config folder detection to macOS and Linux (not just Windows)

## Background

Bforartists uses the base Blender version for its config folder name, not the Bforartists version itself. On Windows, config is stored within the app folder in a version-numbered subfolder (e.g., `5.0/`). This PR adds support for detecting these folders when using "Show Config Folder".
