### PR TITLE
Bump minimum Python version to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "markdown>=3.7",
     "keyring>=25.7.0",
 ]
-requires-python = "<3.15,>=3.10"
+requires-python = "<3.15,>=3.11"
 readme = "README.md"
 license = { text = "GPL3" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10, <3.15"
+requires-python = ">=3.11, <3.15"
 
 [[package]]
 name = "altgraph"


### PR DESCRIPTION
- Update `requires-python` from `>=3.10` to `>=3.11`

The codebase uses `datetime.UTC` (in `source/modules/version_matcher.py`), which was introduced in Python 3.11.

Reference: https://docs.python.org/3/library/datetime.html#datetime.UTC
