### PR TITLE
Replace webbrowser with QDesktopServices for URL handling

### DIFF
--- a/source/widgets/base_build_widget.py
+++ b/source/widgets/base_build_widget.py
@@ -1,12 +1,11 @@
 import abc
 import logging
 import re
-import webbrowser
 from pathlib import PurePosixPath
 
 from PySide6 import QtCore
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction
+from PySide6.QtGui import QAction, QDesktopServices
 from PySide6.QtWidgets import QWidget
 from threads.scraping.bfa import BFA_NC_WEBDAV_SHARE_TOKEN, BFA_NC_WEBDAV_URL, get_bfa_nc_https_download_url
 from webdav4.client import Client
@@ -37,14 +36,15 @@ class BaseBuildWidget(QWidget):
     def show_release_notes(self):
         branch = self.build_info.branch
 
+
         if branch in {"stable", "daily"}:
             ver = self.build_info.semversion
-            webbrowser.open(f"https://wiki.blender.org/wiki/Reference/Release_Notes/{ver.major}.{ver.minor}")
+            QDesktopServices.openUrl(f"https://wiki.blender.org/wiki/Reference/Release_Notes/{ver.major}.{ver.minor}")
         elif branch == "lts":
             # Raw numbers from version
             v = re.sub(r"\D", "", str(self.build_info.semversion.finalize_version()))
 
-            webbrowser.open(f"https://www.blender.org/download/lts/#lts-release-{v}")
+            QDesktopServices.openUrl(f"https://www.blender.org/download/lts/#lts-release-{v}")
         elif self.build_info.branch == "bforartists":
             ver = self.build_info.semversion
             client = Client(BFA_NC_WEBDAV_URL, auth=(BFA_NC_WEBDAV_SHARE_TOKEN, ""))
@@ -55,7 +55,7 @@ class BaseBuildWidget(QWidget):
                 for e in entries:
                     path = PurePosixPath(e["name"])
                     if "releasenote" in path.name.lower():
-                        webbrowser.open(get_bfa_nc_https_download_url(path))
+                        QDesktopServices.openUrl(get_bfa_nc_https_download_url(path))
             except Exception:
                 logger.exception("Failed get Bforartists release note")
         else:
@@ -63,7 +63,7 @@ class BaseBuildWidget(QWidget):
             # Extract only D12345 substring
             m = re.search(r"D\d{5}", branch)
             if m is not None:
-                webbrowser.open(f"https://developer.blender.org/{m.group(0)}")
+                QDesktopServices.openUrl(f"https://developer.blender.org/{m.group(0)}")
 
             # Open for builds with pr123456 name pattern
             # Extract only 123456 substring
@@ -72,4 +72,4 @@ class BaseBuildWidget(QWidget):
             else:
                 m = re.search(r"pr(\d+)", self.build_info.branch, flags=re.IGNORECASE)
             if m is not None:
-                webbrowser.open(f"https://projects.blender.org/blender/blender/pulls/{m.group(1)}")
+                QDesktopServices.openUrl(f"https://projects.blender.org/blender/blender/pulls/{m.group(1)}")

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -29,8 +29,8 @@ from modules.settings import (
     set_favorite_path,
 )
 from modules.shortcut import generate_blender_shortcut, get_default_shortcut_destination
-from PySide6.QtCore import Qt, Signal, Slot
-from PySide6.QtGui import QAction, QDragEnterEvent, QDragLeaveEvent, QDropEvent, QHoverEvent
+from PySide6.QtCore import Qt, QUrl, Signal, Slot
+from PySide6.QtGui import QAction, QDesktopServices, QDragEnterEvent, QDragLeaveEvent, QDropEvent, QHoverEvent
 from PySide6.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
 from threads.observer import Observer
 from threads.register import Register
@@ -48,8 +48,8 @@ from windows.file_dialog_window import FileDialogWindow
 from windows.popup_window import PopupIcon, PopupWindow
 
 if TYPE_CHECKING:
-    from windows.main_window import BlenderLauncher
     from modules.enums import MessageType
+    from windows.main_window import BlenderLauncher
 
 logger = logging.getLogger()
 
@@ -1054,6 +1054,9 @@ class LibraryWidget(BaseBuildWidget):
 
         if not folder_path.is_dir():
             logger.error(f"Path {folder_path} do not exist.")
+            return
+
+        if QDesktopServices.openUrl(QUrl.fromLocalFile(folder_path.as_posix())):
             return
 
         platform = get_platform()

--- a/source/widgets/settings_window/connection_tab.py
+++ b/source/widgets/settings_window/connection_tab.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import webbrowser
-
 from modules.icons import Icons
 from modules.settings import (
     get_github_token,
@@ -239,4 +237,4 @@ class ConnectionTabWidget(SettingsFormWidget):
             )
 
     def open_github_token_docs(self):
-        webbrowser.open("https://Victor-IX.github.io/Blender-Launcher-V2/github_token/")
+        QtGui.QDesktopServices.openUrl("https://Victor-IX.github.io/Blender-Launcher-V2/github_token/")

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -6,7 +6,6 @@ import shlex
 import shutil
 import sys
 import threading
-import webbrowser
 from datetime import datetime
 from enum import Enum
 from functools import partial
@@ -64,7 +63,7 @@ from modules.settings import (
 from modules.string_utils import patch_note_cleaner
 from modules.tasks import TaskQueue, TaskWorker
 from PySide6.QtCore import QSize, Qt, QTimer, Signal, Slot
-from PySide6.QtGui import QAction
+from PySide6.QtGui import QAction, QDesktopServices
 from PySide6.QtWidgets import (
     QApplication,
     QHBoxLayout,
@@ -618,10 +617,10 @@ class BlenderLauncher(BaseWindow):
 
     def show_changelog(self):
         url = f"https://github.com/Victor-IX/Blender-Launcher-V2/releases/tag/v{self.version!s}"
-        webbrowser.open(url)
+        QDesktopServices.openUrl(url)
 
     def open_docs(self):
-        webbrowser.open("https://Victor-IX.github.io/Blender-Launcher-V2")
+        QDesktopServices.openUrl("https://Victor-IX.github.io/Blender-Launcher-V2")
 
     def is_downloading_idle(self):
         download_widgets = []


### PR DESCRIPTION
Switch from using the `webbrowser` module to `QDesktopServices.openUrl` for opening URLs and for opening folders, improving integration with the Qt framework.
This also maintains fallback functionality for opening folders.

Resolves #196

This is a goal given for flatpak integration: https://docs.flatpak.org/en/latest/portals.html#portal-support-in-qt-and-kde

Plus I've made another attempt at a potential flatpak manifest: https://gist.github.com/zeptofine/913b4838aafd2807fb9bc4fcfe622476
Still, not everything works but it is close
