### PR TITLE
Fix UPBGE support on macOS

### DIFF
--- a/source/threads/library_drawer.py
+++ b/source/threads/library_drawer.py
@@ -61,8 +61,6 @@ def get_blender_builds(folders: Iterable[str | Path]) -> Iterable[tuple[Path, bo
                             has_bforartists_exe = (path / build / "Bforartists.app").is_dir()
                         if not has_blender_exe:
                             has_blender_exe = (path / build / "Blender.app").is_dir()
-                        if not has_upbge_exe:
-                            has_upbge_exe = (path / build / "Blender.app").is_dir()
 
                     yield (
                         folder / build,

--- a/source/widgets/download_widget.py
+++ b/source/widgets/download_widget.py
@@ -317,7 +317,7 @@ class DownloadWidget(BaseBuildWidget):
             archive_name=archive_name,
         )
         t.finished.connect(self.download_rename)
-        t.failure.connect(lambda: print("Reading failed"))
+        t.failure.connect(lambda e: logger.error(f"ReadBuildTask failed for {self.build_dir}: {e}"))
         self.parent.task_queue.append(t)
 
     def download_rename(self, build_info: BuildInfo) -> None:


### PR DESCRIPTION
- UPBGE DMG contains multiple apps (Blender.app and Blenderplayer.app), but only one was being copied
- When running `exe -v` fails (e.g., crash), the build info reading now falls back to scraper data
- Unsigned apps were blocked by macOS Gatekeeper quarantine attribute