### PR TITLE
Remove unused imports, re-enable F401 with exceptions in some places

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ target-version = "py311" # our minimum supported version
 
 [tool.ruff.lint]
 extend-ignore = [
-  "F401",   # unused-import -- Certain imports need to be explicitly made, even though they are unused
   "E501",   # line-too-long -- Unavoidable in some cases, but it should still be followed everywhere else
   "SIM114", # if-with-same-arms -- This can make the code harder to read and understand in some places
   "SIM108", # if-else-block-instead-of-if-exp -- Same as above, but this is more common

--- a/source/main.py
+++ b/source/main.py
@@ -12,13 +12,13 @@ from typing import TYPE_CHECKING, NoReturn
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-import modules._resources_rc
+import modules._resources_rc  # noqa: F401
 from modules import argument_parsing as ap
 from modules._platform import _popen, get_cache_path, get_cwd, get_launcher_name, get_platform, is_frozen
 from modules.cli_launching import cli_launch
 from modules.settings import get_auto_register_winget
 from modules.shortcut import register_windows_filetypes, unregister_windows_filetypes
-from modules.version_matcher import VALID_FULL_QUERIES, VALID_QUERIES, VERSION_SEARCH_SYNTAX
+from modules.version_matcher import VALID_FULL_QUERIES, VERSION_SEARCH_SYNTAX
 from modules.winget_integration import register_with_winget
 from PySide6.QtWidgets import QApplication
 from semver import Version

--- a/source/modules/_resources_rc.py
+++ b/source/modules/_resources_rc.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 # resources_rc needs to be imported after PySide6 because
 # if there are any errors importing PySide6
 # it would be registered as an issue fetching the resources instead
-import PySide6
+import PySide6  # noqa: F401
 from modules._platform import is_frozen
 
 try:
-    import resources_rc
+    import resources_rc  # noqa: F401
 
     # Upon importing resources_rc, the :resources QIODevice should be open,
     # and the contained styles should be available for use.

--- a/source/modules/blender_update_manager.py
+++ b/source/modules/blender_update_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from modules.settings import (
     get_bfa_update_behavior,

--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -6,7 +6,7 @@ import re
 import shlex
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 from functools import cache
 from pathlib import Path
 

--- a/source/modules/connection_manager.py
+++ b/source/modules/connection_manager.py
@@ -4,7 +4,7 @@ import logging
 import ssl
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from modules._platform import get_cwd, get_platform_full, is_frozen
 from modules.settings import (

--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import keyring
 from keyring.errors import KeyringError, PasswordDeleteError
-from modules._platform import get_config_file, get_config_path, get_cwd, get_platform, local_config, user_config
+from modules._platform import get_config_file, get_config_path, get_cwd, local_config, user_config
 from modules.bl_api_manager import dropdown_blender_version
 from modules.version_matcher import VersionSearchQuery
 from PySide6.QtCore import QSettings

--- a/source/modules/shortcut.py
+++ b/source/modules/shortcut.py
@@ -17,7 +17,6 @@ def generate_blender_shortcut(folder, name, destination: Path):
 
     if sys.platform == "win32":
         import win32com.client
-        from win32comext.shell import shell, shellcon
 
         targetpath = library_folder / folder / "blender.exe"
         workingdir = library_folder / folder

--- a/source/modules/winget_integration.py
+++ b/source/modules/winget_integration.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-import sys
 from pathlib import Path
 
 from modules._platform import get_platform

--- a/source/threads/extractor.py
+++ b/source/threads/extractor.py
@@ -6,7 +6,6 @@ import zipfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import py7zr
 from modules._platform import _check_call, _check_output

--- a/source/widgets/base_build_widget.py
+++ b/source/widgets/base_build_widget.py
@@ -15,7 +15,6 @@ from webdav4.client import Client
 from widgets.base_menu_widget import BaseMenuWidget
 
 if TYPE_CHECKING:
-    from modules.build_info import BuildInfo
     from items.base_list_widget_item import BaseListWidgetItem
     from modules.build_info import BuildInfo
     from windows.main_window import BlenderLauncher

--- a/source/widgets/base_list_widget.py
+++ b/source/widgets/base_list_widget.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from modules.version_matcher import BasicBuildInfo, VersionSearchQuery

--- a/source/widgets/datetime_widget.py
+++ b/source/widgets/datetime_widget.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QEvent, Qt
-from PySide6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QSizePolicy
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QPushButton
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/source/widgets/download_widget.py
+++ b/source/widgets/download_widget.py
@@ -5,7 +5,7 @@ import re
 import shutil
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from modules.build_info import BuildInfo, ReadBuildTask, parse_blender_ver
 from modules.enums import MessageType
@@ -25,7 +25,6 @@ from widgets.elided_text_label import ElidedTextLabel
 from windows.popup_window import PopupIcon, PopupWindow
 
 if TYPE_CHECKING:
-    from widgets.base_page_widget import BasePageWidget
     from widgets.library_widget import LibraryWidget
     from windows.main_window import BlenderLauncher
 

--- a/source/widgets/library_damaged_widget.py
+++ b/source/widgets/library_damaged_widget.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from modules.build_info import BuildInfo
 from modules.settings import get_library_folder
-from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtCore import Qt, Slot
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget
 from threads.remover import RemovalTask
 from widgets.base_build_widget import BaseBuildWidget

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -30,7 +30,7 @@ from modules.settings import (
     set_favorite_path,
 )
 from modules.shortcut import generate_blender_shortcut, get_default_shortcut_destination
-from PySide6.QtCore import Qt, QUrl, Signal, Slot
+from PySide6.QtCore import Qt, QUrl, Slot
 from PySide6.QtGui import QAction, QDesktopServices, QDragEnterEvent, QDragLeaveEvent, QDropEvent, QHoverEvent
 from PySide6.QtWidgets import QApplication, QHBoxLayout, QLabel, QWidget
 from threads.observer import Observer

--- a/source/widgets/repo_group.py
+++ b/source/widgets/repo_group.py
@@ -12,8 +12,7 @@ from modules.settings import (
     get_show_upbge_builds,
     get_show_upbge_weekly_builds,
 )
-from PySide6.QtCore import Slot
-from PySide6.QtWidgets import QButtonGroup, QFrame, QSizePolicy, QVBoxLayout
+from PySide6.QtWidgets import QFrame, QSizePolicy, QVBoxLayout
 from widgets.repo_visibility_view import RepoUserView
 
 

--- a/source/widgets/repo_visibility_view.py
+++ b/source/widgets/repo_visibility_view.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
-from PySide6.QtWidgets import QButtonGroup, QCheckBox, QGridLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QCheckBox, QGridLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget
 
 
 class RepoUserView(QWidget):

--- a/source/widgets/settings_window/blender_builds_tab.py
+++ b/source/widgets/settings_window/blender_builds_tab.py
@@ -88,7 +88,6 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QSpinBox,
-    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )

--- a/source/widgets/settings_window/general_tab.py
+++ b/source/widgets/settings_window/general_tab.py
@@ -35,7 +35,6 @@ from modules.settings import (
 )
 from modules.shortcut import generate_program_shortcut, get_default_program_shortcut_destination, get_shortcut_type
 from modules.winget_integration import register_with_winget, unregister_from_winget
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QCheckBox, QComboBox, QGridLayout, QLabel, QPushButton, QSpinBox
 from widgets.folder_select import FolderSelector
 from widgets.settings_form_widget import SettingsFormWidget

--- a/source/windows/base_window.py
+++ b/source/windows/base_window.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from modules.connection_manager import ConnectionManager
 from modules.icons import Icons
 from modules.settings import get_use_system_titlebar
-from PySide6.QtCore import QFile, QPoint, Qt, QTextStream
+from PySide6.QtCore import QFile, Qt, QTextStream
 from PySide6.QtGui import QFont, QFontDatabase
 from PySide6.QtWidgets import QApplication, QMainWindow
 

--- a/source/windows/custom_build_dialog_window.py
+++ b/source/windows/custom_build_dialog_window.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import logging
 import os
 from enum import Enum

--- a/source/windows/launching_window.py
+++ b/source/windows/launching_window.py
@@ -4,7 +4,6 @@ import contextlib
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from items.enablable_list_widget_item import EnablableListWidgetItem
 from modules.blendfile_reader import BlendfileHeader, read_blendfile_header
@@ -24,9 +23,6 @@ from PySide6.QtWidgets import QApplication, QComboBox, QGridLayout, QLabel, QLis
 from threads.library_drawer import DrawLibraryTask
 from widgets.lintable_line_edit import LintableLineEdit
 from windows.base_window import BaseWindow
-
-if TYPE_CHECKING:
-    from datetime import datetime
 
 logger = logging.getLogger()
 

--- a/source/windows/main_window.py
+++ b/source/windows/main_window.py
@@ -110,9 +110,6 @@ except Exception as e:
 
 if TYPE_CHECKING:
     from modules.build_info import BuildInfo
-    from PySide6.QtGui import QDragEnterEvent, QDragMoveEvent
-    from widgets.base_build_widget import BaseBuildWidget
-    from widgets.base_list_widget import BaseListWidget
 
 # if get_platform() == "Windows":
 #     from PySide6.QtWinExtras import QWinThumbnailToolBar, QWinThumbnailToolButton

--- a/source/windows/popup_window.py
+++ b/source/windows/popup_window.py
@@ -1,6 +1,5 @@
 import textwrap
 from enum import Enum
-from typing import Optional
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QKeyEvent, QPixmap


### PR DESCRIPTION
It's a good rule to follow, and the very few cases where we need to has been labeled as exceptions.

one thing I'm not sure of, the shortcut function for windows imports some shell, shellcon. I can't tell if those are hidden imports / requirements. Could someone on Windows double check if this functionality still works with those imports missing?