### PR TITLE
feat: add a GLIBC warning on Linux if it fails to import

### DIFF
--- a/source/modules/_resources_rc.py
+++ b/source/modules/_resources_rc.py
@@ -1,15 +1,42 @@
 from __future__ import annotations
 
+# ruff: disable[F401]
+import sys
+import traceback
 from pathlib import Path
 
 # resources_rc needs to be imported after PySide6 because
 # if there are any errors importing PySide6
 # it would be registered as an issue fetching the resources instead
-import PySide6  # noqa: F401
+try:
+    import PySide6
+    import PySide6.QtCore
+except ImportError as e:
+    traceback.print_exc()
+    print("Failed to import PySide6.")
+    if "GLIBC" in e.msg:
+        # try to fetch the current glibc version
+        import subprocess
+
+        try:
+            current_glibc = subprocess.check_output(["ldd", "--version"], timeout=0.5)
+            print(
+                f"Your GLIBC version ({current_glibc.splitlines()[0].strip()}) may be older than this build's supported version."
+            )
+        except subprocess.TimeoutExpired:
+            print("Your GLIBC version may be older than this build's supported version.")
+        print("If you are attempting to run the Linux_x64 build, see if the Ubuntu builds work for you.")
+        print(
+            "Those are built on an older version of GLIBC and should be more compatible with more LTS and stable Linux versions."
+        )
+
+    sys.exit()
+
+
 from modules.platform_utils import is_frozen
 
 try:
-    import resources_rc  # noqa: F401
+    import resources_rc
 
     # Upon importing resources_rc, the :resources QIODevice should be open,
     # and the contained styles should be available for use.
@@ -26,3 +53,5 @@ except ImportError:
         print("Resources were not built! build the style so the launcher looks right.")
 
         raise
+
+# ruff: enable[F401]


### PR DESCRIPTION
This doesn't address *why* there is a GLIBC version discrepancy but at least this could assist people in what to do when they encounter it.

Verified on a fresh Ubuntu Desktop 24.04 LTS VM.