### PR TITLE
fix: correct misspelled i18n keys to match yaml definitions

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -263,7 +263,7 @@ def start_set_library_folder(app: QApplication, lib_folder: str):
     else:
         logging.error("Failed to set library folder")
         Popup.warning(
-            message=t("msg.err.library_invalid"),
+            message=t("msg.err.folder_invalid"),
             buttons=Popup.Button.QUIT,
             app=app,
         ).show()

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -198,7 +198,7 @@ class LibraryWidget(BaseBuildWidget):
         self.addToFavoritesAction.setIcon(self.launcher.icons.favorite)
         self.addToFavoritesAction.triggered.connect(self.add_to_favorites)
 
-        self.removeFromFavoritesAction = QAction(t("act.fav.rem"), self)
+        self.removeFromFavoritesAction = QAction(t("act.a.fav.rem"), self)
         self.removeFromFavoritesAction.setIcon(self.launcher.icons.favorite)
         self.removeFromFavoritesAction.triggered.connect(self.remove_from_favorites)
 

--- a/source/windows/main_window/window.py
+++ b/source/windows/main_window/window.py
@@ -275,7 +275,7 @@ class BlenderLauncher(BaseWindow):
         else:
             self.dlg = Popup.warning(
                 parent=self,
-                message=t("err.folder_invalid"),
+                message=t("msg.err.folder_invalid"),
                 buttons=Popup.Button.RETRY,
             )
             self.dlg.accepted.connect(self.prompt_library_folder)


### PR DESCRIPTION
## Problem

Three `t()` call sites in the source code referenced i18n keys that don't exist in any `*.en.yml` (or other locale) file. When this happens the i18n library renders the raw key string to the user, so the issue affects **every language**, not just non-English locales.

The breakage was discovered while looking into `act.fav.rem` showing untranslated in Japanese.

## Fixes

| File | Before | After | Notes |
| --- | --- | --- | --- |
| `source/widgets/library_widget.py:201` | `t("act.fav.rem")` | `t("act.a.fav.rem")` | The matching add action on line 197 already uses `act.a.fav.add` — only the remove action was misspelled. |
| `source/windows/main_window/window.py:278` | `t("err.folder_invalid")` | `t("msg.err.folder_invalid")` | Missing `msg.` prefix on the invalid-library-folder retry dialog. |
| `source/main.py:266` | `t("msg.err.library_invalid")` | `t("msg.err.folder_invalid")` | `library_invalid` was never defined in any yaml. `folder_invalid` ("Selected folder is not a valid folder or it doesn't have write permissions!") fits the `set_library_folder` failure case and is what the in-app retry path already uses, so reusing it keeps the wording consistent. |

## Verification

Cross-referencing every `t("...")` call against the flattened keys defined in `source/resources/localization/*.en.yml` (using the filename category as the prefix, matching `i18n.set("skip_locale_root_data", True)` behaviour):

```
Total t() keys used : 216
Defined en keys     : 408
Missing in en yaml  : 0   (was 3 before this PR)
```

## Test plan

- [ ] Launch the app in English: the "Remove from Favorites" context menu item shows the localized label instead of `act.fav.rem`.
- [ ] Launch the app in Japanese / French / Spanish / Chinese: the same action shows the locale-specific translation.
- [ ] Pick an invalid library folder from settings (e.g. a read-only location): the retry dialog message is localized, not `err.folder_invalid`.
- [ ] Pass an invalid `--library-folder` on the command line to trigger the QUIT popup in `main.py`: the message is localized, not `msg.err.library_invalid`.