### PR TITLE
fix: trigger LibraryWidget left-release side effects (button() call)

### DIFF
--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -378,7 +378,7 @@ class LibraryWidget(BaseBuildWidget):
             self.launch(launch_mode=LaunchOpenLast())
 
     def mouseReleaseEvent(self, event):
-        if event.button == Qt.MouseButton.LeftButton:
+        if event.button() == Qt.MouseButton.LeftButton:
             if self.show_new is True:
                 self.build_state_widget.setNewBuild(False)
                 self.show_new = False


### PR DESCRIPTION
## Problem

`LibraryWidget.mouseReleaseEvent` (`source/widgets/library_widget.py:380-396`) has compared the bound method `event.button` (a callable, always truthy) against the enum `Qt.MouseButton.LeftButton` since commit 2d4fbfca (2020-10-18, "Add support for extended selection in library"). The comparison is always `False`, so the left-button branch — which clears the "new build" indicator and explicitly manages the list selection — has been **dead code for roughly five years**.

The typo affects every platform, not just macOS, which is why it's separated from #399.

Adding the missing `()` restores the originally-intended behaviour:

- On left-button release over the widget body (i.e. not on the launch/update child buttons): clear the new-build dot indicator (`self.show_new = False`) and, when no Shift/Ctrl modifier is held, ensure this row is the sole selection.
- All other release events stay no-ops, as before.

The trailing unconditional `event.ignore()` is preserved so the event still propagates to `QListWidget` and its native selection handling continues to run; that's needed to keep Shift/Ctrl multi-select working as today.

## Why I believe this is safe (but please double-check)

I traced the impact carefully and **I think there are no functional regressions**, but because this code path has been silently disabled since 2020 the practical "before/after" can only be confirmed by trying the app:

- **Right-click / context menu**: unaffected — only `LeftButton` enters the branch.
- **Clicks on the inner `launchButton` / `updateButton`**: unaffected — `QAbstractButton` consumes the press/release before it reaches `LibraryWidget`.
- **Drag-and-drop (`.blend` onto a row)**: unaffected — separate event path.
- **Modifier-aware selection**: the new branch only runs `clearSelection()` + `setSelected(True)` when no modifier is held, so Shift/Ctrl multi-select still falls through to `QListWidget`'s native handling.
- **Selection signal storm**: the only `itemSelectionChanged` subscriber in the codebase is in `windows/launching_window.py` on a different `QListWidget` instance (`builds_list`), so the redundant manual selection update on the LibraryPage list does not trigger extra handlers.
- **`event.accept()` followed by `event.ignore()`**: this remains a no-op-then-ignore pattern (final state = ignored), so event propagation to `QListWidget` is unchanged. I deliberately kept it as-is rather than restructuring, to minimise the surface of this change.

The main observable behavioural change is that the "new build" dot indicator now clears when the user left-clicks anywhere on the row, instead of only when they hit the Launch button. That matches the developer intent visible in the 2020 diff and in the parallel code in `widgets/download_widget.py:175`.