### PR TITLE
fix: use BMP arrow (U+2192) in restart-pending messages

### DIFF
--- a/source/windows/settings_window/window.py
+++ b/source/windows/settings_window/window.py
@@ -160,7 +160,7 @@ class SettingsWindow(BaseWindow):
             pending_to_restart.append(
                 t("settings.connection.use_custom_tls_certificates")
                 + checkdct[self.old_use_custom_tls_certificates]
-                + "🠆"
+                + "→"
                 + checkdct[use_custom_tls_certificates]
             )
 
@@ -168,23 +168,23 @@ class SettingsWindow(BaseWindow):
             r_proxy_types = dict(zip(proxy_types.values(), proxy_types.keys(), strict=True))
 
             pending_to_restart.append(
-                f"{t('settings.connection.proxy_type')}: {r_proxy_types[self.old_proxy_type]}🠆{r_proxy_types[proxy_type]}"
+                f"{t('settings.connection.proxy_type')}: {r_proxy_types[self.old_proxy_type]}→{r_proxy_types[proxy_type]}"
             )
 
         if self.old_proxy_host != proxy_host:
-            pending_to_restart.append(f"{t('settings.connection.proxy_host')}: {self.old_proxy_host}🠆{proxy_host}")
+            pending_to_restart.append(f"{t('settings.connection.proxy_host')}: {self.old_proxy_host}→{proxy_host}")
 
         if self.old_proxy_port != proxy_port:
-            pending_to_restart.append(f"{t('settings.connection.proxy_port')}: {self.old_proxy_port}🠆{proxy_port}")
+            pending_to_restart.append(f"{t('settings.connection.proxy_port')}: {self.old_proxy_port}→{proxy_port}")
 
         if self.old_proxy_user != proxy_user:
-            pending_to_restart.append(f"{t('settings.connection.proxy_user')}: {self.old_proxy_user}🠆{proxy_user}")
+            pending_to_restart.append(f"{t('settings.connection.proxy_user')}: {self.old_proxy_user}→{proxy_user}")
 
         if self.old_proxy_password != proxy_password:
             pending_to_restart.append(t("settings.connection.proxy_password"))
 
         if self.old_user_id != user_id:
-            pending_to_restart.append(f"{t('settings.connection.user_id')}: {self.old_user_id}🠆{user_id}")
+            pending_to_restart.append(f"{t('settings.connection.user_id')}: {self.old_user_id}→{user_id}")
 
         """Update build check frequency"""
         check_for_new_builds_automatically = get_check_for_new_builds_automatically()
@@ -202,7 +202,7 @@ class SettingsWindow(BaseWindow):
 
         if self.old_dpi_scale_factor != dpi_scale_factor:
             pending_to_restart.append(
-                f"{t('settings.appearance.dpi_scale_factor')}: {self.old_dpi_scale_factor:.2f}🠆{dpi_scale_factor:.2f}",
+                f"{t('settings.appearance.dpi_scale_factor')}: {self.old_dpi_scale_factor:.2f}→{dpi_scale_factor:.2f}",
             )
 
         """Update worker thread count"""
@@ -210,14 +210,14 @@ class SettingsWindow(BaseWindow):
 
         if self.old_thread_count != worker_thread_count:
             pending_to_restart.append(
-                f"{t('settings.general.app.worker_count')}: {self.old_thread_count}🠆{worker_thread_count}"
+                f"{t('settings.general.app.worker_count')}: {self.old_thread_count}→{worker_thread_count}"
             )
 
         """Update language"""
         language = get_language()
 
         if self.old_language != language:
-            pending_to_restart.append(f"{t('settings.general.app.language')}: {self.old_language}🠆{language}")
+            pending_to_restart.append(f"{t('settings.general.app.language')}: {self.old_language}→{language}")
 
         return pending_to_restart
 


### PR DESCRIPTION
## Problem

When a setting that requires a restart is changed in the Settings window, the confirmation dialog lists each change as `<label>: <old>🠆<new>` (e.g. `DPIスケール倍率: 1.00🠆1.20`). On macOS — most reproducibly when the UI language is Japanese — the arrow rendered as tofu (□) because the system fallback chain could not find a glyph for it.

### Root cause: the arrow lives outside the BMP

The character used in `source/windows/settings_window/window.py` was `🠆` (U+1F806, *RIGHTWARDS ARROW WITH MEDIUM TRIANGLE ARROWHEAD*), which belongs to the **Supplemental Arrows-C** block added in **Unicode 7.0 (2014)**. It is a 4-byte UTF-8 / surrogate-pair SMP codepoint, and almost no shipping system fonts cover it — in particular no CJK font on macOS (Hiragino, PingFang) does. When Qt couldn't find a glyph it fell back to tofu and, on some macOS text runs, broke the rest of the line.

| | `🠆` | `→` |
| --- | --- | --- |
| Codepoint | U+1F806 | U+2192 |
| UTF-8 | `f0 9f a0 86` (4 bytes) | `e2 86 92` (3 bytes) |
| Block | Supplemental Arrows-C | Arrows |
| Added in | Unicode 7.0 (2014) | Unicode 1.1 (1993) |
| Font coverage | Symbola / Noto Sans Symbols 2 only | Practically every system font |

`→` (U+2192) is in the original BMP *Arrows* block, is in JIS X 0208 / GB 2312 (so every CJK font carries it), and is part of WGL4 (so every Microsoft-shipped font carries it). It renders identically on macOS Japanese, Chinese, French, and English, which are the four locales this project ships.

## Fix

Replace all 9 occurrences of `🠆` (U+1F806) with `→` (U+2192) in `source/windows/settings_window/window.py`. The affected messages cover: custom TLS certificates toggle, proxy type/host/port/user, user ID, DPI scale factor, worker thread count, and language.

No other source files used the SMP arrow — `grep -rn $'\U0001F806'` returned only this one file.

## Test plan

- [ ] On macOS with the launcher language set to Japanese, change *DPI スケール倍率* in the Appearance tab and click OK — the restart-pending list shows `DPIスケール倍率: 1.00→1.20` with a proper arrow glyph (no tofu).
- [ ] Repeat on macOS in English / French / Chinese — arrow renders cleanly in all four shipped locales.
- [ ] Sanity check on Windows and Linux that the arrow still renders (U+2192 is universally covered, so this should be a no-op visual change there).
- [ ] Trigger at least one other entry in the same list (e.g. change *Worker thread count* or *Language*) to confirm every replaced site still formats correctly.