### PR TITLE
fix: detect macOS UI language via AppleLocale for Auto setting

### DIFF
--- a/source/utils/i18n_init.py
+++ b/source/utils/i18n_init.py
@@ -1,6 +1,7 @@
 import locale
 import logging
 import os
+import subprocess
 import sys
 from enum import StrEnum
 from pathlib import Path
@@ -50,6 +51,21 @@ def _detect_os_locale() -> str:
             loc = locale.windows_locale[windll.GetUserDefaultUILanguage()]
         except (KeyError, OSError):
             loc = "en_US"
+    elif sys.platform == "darwin":
+        # On macOS, LANG and friends are not set when launched from Finder/Dock,
+        # and Qt/Python's locale detection does not consult the system settings,
+        # so read AppleLocale (e.g. "ja_JP") directly via `defaults`.
+        try:
+            result = subprocess.run(
+                ["defaults", "read", "-g", "AppleLocale"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=True,
+            )
+            loc = result.stdout.strip() or "en_US"
+        except (subprocess.SubprocessError, OSError):
+            loc = os.environ.get("LANG") or locale.getlocale()[0] or "en_US"
     elif (x := os.environ.get("LANG")) is not None:
         loc = x
     elif (x := locale.getlocale()[0]) is not None:


### PR DESCRIPTION
## Problem

When *Settings → Language* is set to **Auto**, the launcher should pick up the user's OS language. On Windows this works, but on macOS the Auto setting always fell back to English regardless of the user's *System Settings → Language & Region* choice.

## Fix

Read `AppleLocale` directly through the `defaults` CLI on the `darwin` branch in `source/utils/i18n_init.py`, then reuse the existing `split("_", 1)[0]` reduction to a 2-letter code. If `defaults` fails, fall back to the previous `LANG` / `locale.getlocale()` chain.

Verified on macOS with system language set to **日本語**: launcher with `Language = Auto` now starts in Japanese (previously English).