### PR TITLE
fix: clamp window position to screen so header stays reachable at high DPI

### DIFF
--- a/source/windows/base_window.py
+++ b/source/windows/base_window.py
@@ -101,12 +101,22 @@ class BaseWindow(QMainWindow):
             if launcher.isVisible():
                 x = launcher.x() + (launcher.width() - self.width()) * 0.5
                 y = launcher.y() + (launcher.height() - self.height()) * 0.5
+                screen = launcher.screen() or launcher.app.primaryScreen()
             else:
-                size = launcher.app.screens()[0].size()
-                x = (size.width() - self.width()) * 0.5
-                y = (size.height() - self.height()) * 0.5
+                screen = launcher.app.primaryScreen()
+                geo = screen.availableGeometry()
+                x = geo.left() + (geo.width() - self.width()) * 0.5
+                y = geo.top() + (geo.height() - self.height()) * 0.5
 
-            self.move(int(x), int(y))
+            # Clamp to the screen's available area so the header stays reachable when the
+            # window is taller than the screen (e.g. macOS with a high DPI scale factor).
+            avail = screen.availableGeometry()
+            max_x = avail.left() + max(0, avail.width() - self.width())
+            max_y = avail.top() + max(0, avail.height() - self.height())
+            x = max(avail.left(), min(int(x), max_x))
+            y = max(avail.top(), min(int(y), max_y))
+
+            self.move(x, y)
             event.accept()
 
     def _destroyed(self):


### PR DESCRIPTION
## Problem

On macOS, raising *Settings → Appearance → DPI Scale Factor* above 1.0 caused the Settings window to open with its top edge pushed off the screen. The header (and the system title bar when enabled) ended up hidden behind the macOS menu bar, leaving the window un-draggable and the close/minimize controls unreachable.

`SettingsWindow` resizes to `QSize(700, 800)` with a minimum of `(500, 600)`. Those numbers are in Qt's logical coordinate space, which `QT_SCALE_FACTOR` scales up — at 1.5× the window is 1200 logical px tall, exceeding the usable height of a typical 13"/14" Mac display once the menu bar is removed. `BaseWindow.showEvent` then computed `y = launcher.y() + (launcher.height() - self.height()) * 0.5`, which is negative when the window is taller than the launcher, pushing the header off-screen.

## Fix

In `source/windows/base_window.py`, after centering on the launcher (or the screen, when the launcher isn't visible yet), clamp the resulting `(x, y)` to the target screen's `availableGeometry()`. `availableGeometry()` excludes the macOS menu bar / Dock (and the Windows taskbar), so this keeps the top-left of the window inside the usable region even when the window itself is larger than the screen.

Also use `launcher.screen()` (with a `primaryScreen()` fallback) instead of `screens()[0]` so the window opens on the same display as the launcher in multi-monitor setups.