### PR TITLE
Fix for Custom Builds Library duplicated entrys and minor favourite functionality improvements

### DIFF
--- a/source/widgets/base_list_widget.py
+++ b/source/widgets/base_list_widget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from modules.version_matcher import BasicBuildInfo, VersionSearchQuery
@@ -73,6 +74,17 @@ class BaseListWidget(Generic[_WT], QListWidget):
 
     def _cache_widget(self, widget):
         self._binfos_cache.setdefault(self.basic_from_widget(widget), set()).add(widget)
+
+    def widget_with_link(self, link: Path) -> _WT | None:
+        # LibraryWidget/LibraryDamagedWidget use `link`; UnrecoBuildWidget uses `path`.
+        try:
+            return next(
+                widget
+                for widget in self.widgets
+                if getattr(widget, "link", None) == link or getattr(widget, "path", None) == link
+            )
+        except StopIteration:
+            return None
 
     def remove_item(self, item):
         if (w := self.itemWidget(item)) is not None:
@@ -180,8 +192,12 @@ class BaseListWidget(Generic[_WT], QListWidget):
 
         item.setHidden(not success)
 
-    def clear_by_branch(self, branch: str):
-        widgets_to_remove = [widget for widget in self.widgets if widget.build_info.branch == branch]
+    def clear_by_folder(self, folder: str):
+        def widget_folder(w):
+            path = getattr(w, "link", None) or getattr(w, "path", None)
+            return Path(path).parent.name if path is not None else None
+
+        widgets_to_remove = [widget for widget in self.widgets if widget_folder(widget) == folder]
         for widget in widgets_to_remove:
             items = [self.item(i) for i in range(self.count()) if self.itemWidget(self.item(i)) == widget]
             for item in items:

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -927,6 +927,13 @@ class LibraryWidget(BaseBuildWidget):
 
     @Slot()
     def add_to_favorites(self):
+        # Replace any stale favourites entry: __init__ caches display state from
+        # build_info, so reusing the widget would show stale labels after edits.
+        # Path-keyed because BuildInfo.__eq__ ignores path.
+        stale = self.launcher.FavoritesPage.list_widget.widget_with_link(self.link)
+        if stale is not None:
+            self.launcher.FavoritesPage.list_widget.remove_item(stale.item)
+
         item = BaseListWidgetItem()
         widget = LibraryWidget(
             self.launcher,
@@ -936,8 +943,7 @@ class LibraryWidget(BaseBuildWidget):
             build_info=self.build_info,
             parent_widget=self,
         )
-        if not self.launcher.FavoritesPage.list_widget.contains_build_info(self.build_info):
-            self.launcher.FavoritesPage.list_widget.insert_item(item, widget)
+        self.launcher.FavoritesPage.list_widget.insert_item(item, widget)
         self.child_widget = widget
 
         self.removeFromFavoritesAction.setVisible(True)
@@ -948,13 +954,21 @@ class LibraryWidget(BaseBuildWidget):
 
     @Slot()
     def remove_from_favorites(self):
-        widget = self.parent_widget or self
-        assert widget.child_widget is not None
-        self.launcher.FavoritesPage.list_widget.remove_item(widget.child_widget.item)
+        # Either side may be None if a reload destroyed its counterpart.
+        if self.list_widget is self.launcher.FavoritesPage.list_widget:
+            fav_widget = self
+            lib_widget = self.parent_widget
+        else:
+            lib_widget = self
+            fav_widget = self.child_widget
 
-        widget.child_widget = None
-        widget.removeFromFavoritesAction.setVisible(False)
-        widget.addToFavoritesAction.setVisible(True)
+        if fav_widget is not None:
+            self.launcher.FavoritesPage.list_widget.remove_item(fav_widget.item)
+
+        if lib_widget is not None:
+            lib_widget.child_widget = None
+            lib_widget.removeFromFavoritesAction.setVisible(False)
+            lib_widget.addToFavoritesAction.setVisible(True)
 
         self.build_info.is_favorite = False
         self.build_info_writer = WriteBuildTask(self.link, self.build_info)
@@ -1125,6 +1139,14 @@ class LibraryWidget(BaseBuildWidget):
         self.show_folder(path)
 
     def _destroyed(self):
+        # Sever cross-links so the surviving counterpart doesn't dereference a dead C++ object.
+        if self.child_widget is not None:
+            self.child_widget.parent_widget = None
+            self.child_widget = None
+        if self.parent_widget is not None:
+            self.parent_widget.child_widget = None
+            self.parent_widget = None
+
         if self.launcher.quick_launch_handler.quick_launch_build == self:
             self.launcher.quick_launch_handler.remove_quick_launch()
 

--- a/source/windows/main_window/window.py
+++ b/source/windows/main_window/window.py
@@ -631,7 +631,7 @@ class BlenderLauncher(BaseWindow):
         self.task_queue.append(self.library_drawer)
 
     def reload_custom_builds(self):
-        self.LibraryPage.list_widget.clear_by_branch("custom")
+        self.LibraryPage.list_widget.clear_by_folder("custom")
         self.library_drawer = DrawLibraryTask(["custom"])
         self.library_drawer.found.connect(self.draw_to_library)
         self.library_drawer.unrecognized.connect(self.draw_unrecognized)
@@ -781,6 +781,16 @@ class BlenderLauncher(BaseWindow):
         self.task_queue.append(a)
 
     def draw_read_library(self, path, show_new, binfo: BuildInfo, successful_read_callback):
+        # Scan callbacks are uncancellable, so a stale read can land after a
+        # new scan starts. Dedupe; replace any damaged placeholder.
+        existing = self.LibraryPage.list_widget.widget_with_link(path)
+        if isinstance(existing, LibraryWidget):
+            if successful_read_callback is not None:
+                successful_read_callback(existing)
+            return existing
+        if existing is not None:
+            self.LibraryPage.list_widget.remove_item(existing.item)
+
         item = BaseListWidgetItem()
         widget = LibraryWidget(self, item, path, self.LibraryPage.list_widget, binfo, show_new)
         widget.add_as_quick_launch.connect(self.quick_launch_handler.set_quick_launch_build)
@@ -796,6 +806,9 @@ class BlenderLauncher(BaseWindow):
     def draw_damaged_library(self, path: Path, exc: Exception | None = None):
         if exc:
             logger.error(f"Failed to read build info for {path}: {exc}")
+
+        if self.LibraryPage.list_widget.widget_with_link(path) is not None:
+            return None
 
         item = BaseListWidgetItem()
         widget = LibraryDamagedWidget(self, item, path, self.LibraryPage.list_widget)
@@ -816,6 +829,9 @@ class BlenderLauncher(BaseWindow):
             "upbge-weekly",
             "custom",
         ):
+            return
+
+        if self.LibraryPage.list_widget.widget_with_link(path) is not None:
             return
 
         item = BaseListWidgetItem()


### PR DESCRIPTION
Hi,
So I discovered some minor bugs which I documented in the closely adjacent closed issue https://github.com/Victor-IX/Blender-Launcher-V2/issues/34 . I wanted to try contributing out of curiosity and see how it would be resolve them. **Disclaimer** the code was written by claude and im not a proper developer but I did my best to troubleshoot everything and test it as best I could through running the program and trying it myself, conducting ruff and pytest, and having the AI peer review it afterwards. 

Hopefully what was able to be made might be of use towards fixing the issue! Thanks again, yall are doing amazing work >:)

### Documented but were not implemented: 
-The ordering is not perfect, if you choose to sort by version and then click reload it will not sort those reloaded results properly unless you tell it to sort again 
-library_widget.py (line 35): Ruff fails on unused import set_favorite_path. This however seems to have been present before these changes