### PR TITLE
feat: necessary modifications and related files for Flatpak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,13 @@ source/resources/styles/global.qss
 # Mac
 .DS_Store
 
+# Flatpak ...
+flatpak-files/python3-modules.yaml
+# flatpak build directories have builtin `.gitignore`s.
+# ...except for this one
+flatpak-files/repo/
+
+
 # Application related settings
 Blender Launcher.ini
 log_file.txt

--- a/flatpak-files/build-and-install.sh
+++ b/flatpak-files/build-and-install.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Builds the flatpak while installing required dependencies and installs it in your user folder.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" > /dev/null && pwd )
+cd "$SCRIPT_DIR" || exit
+
+YML_FILENAME="io.github.Victor_IX.Blender-Launcher-V2.yml"
+
+
+if command -v flatpak-builder > /dev/null 2>&1; then
+    cmd="flatpak-builder --force-clean flatpak-build-dir --install-deps-from flathub ${YML_FILENAME} --user --install"
+elif command -v flatpak > /dev/null 2>&1; then
+    if ! flatpak info org.flatpak.Builder > /dev/null 2>&1; then
+        echo
+        echo "org.flatpak.Builder not found. Please install it:"
+        echo "flatpak install org.flatpak.Builder"
+        exit 1
+    fi
+    cmd="flatpak run --command=flathub-build org.flatpak.Builder --force-clean  --user --install ${YML_FILENAME}"
+else
+    echo "Neither flatpak-builder nor flatpak were found."
+    exit 1
+fi
+
+$cmd

--- a/flatpak-files/generate_flatpak_modules.py
+++ b/flatpak-files/generate_flatpak_modules.py
@@ -5,9 +5,9 @@
 
 
 # The path to the lockfile used to resolve pip hashes and wheels.
-
 LOCKFILE_PATH = "uv.lock"
-OUTPUT_PATH = "python3-modules.yaml"
+# Output.
+OUTPUT_PATH = "flatpak-files/python3-modules.yaml"
 
 # The name of the target package.
 ROOT_PACKAGE = "blender-launcher-v2"
@@ -15,26 +15,19 @@ ROOT_PACKAGE = "blender-launcher-v2"
 IGNORE_DEPS = {
     "pyinstaller",  # irrelevant
     "pyside6-essentials",  # handled by io.qt.PySide.BaseApp
-    "pynput", # handled by external tools.
+    "pynput",  # handled by external tools.
 }
-RUNTIME = "io.qt.PySide.BaseApp"
+# Used to check system attributes against.
+RUNTIME = "io.qt.PySide.BaseApp//6.10"
 
 import shlex
 import subprocess
 import tomllib
 from collections import deque
-from pathlib import Path
 
-try:
-    import yaml
-    from packaging.tags import Tag, create_compatible_tags_selector
-    from packaging.utils import parse_wheel_filename
-except ImportError:
-    print(
-        "Failed to import necessary modules. please install `PyYAML` and `packaging`."
-    )
-    print("`uv pip install PyYAML packaging`")
-
+import yaml
+from packaging.tags import Tag, create_compatible_tags_selector
+from packaging.utils import parse_wheel_filename
 
 with open(LOCKFILE_PATH, "rb") as f:
     t = tomllib.load(f)
@@ -42,26 +35,14 @@ with open(LOCKFILE_PATH, "rb") as f:
     assert t["revision"] == 3
 
 # TODO sanitize output - serialize and deserialize?
-tags_path = Path("/tmp/flatpak-pyside-base-tags")
-if tags_path.exists():
-    valid_tags = {
-        Tag(*t.split("-"))
-        for t in eval(Path("/tmp/flatpak-pyside-base-tags").read_text())
-    }
-else:
-    with tags_path.open("wb") as f:
-        s = subprocess.check_output(
-            f'flatpak --arch=x86_64 --devel --command=python3 run {RUNTIME} -c "from packaging import tags; print(list(map(str,tags.sys_tags())))"',
-            shell=True,
-        )
-        print(s)
-        f.write(s)
-        valid_tags = {Tag(*t.split("-")) for t in eval(s.strip())}
-
-
-packages = sorted(
-    t["package"], key=lambda x: len(x["dependencies"]) if "dependencies" in x else 0
+s = subprocess.check_output(
+    f'flatpak --arch=x86_64 --command=python3 run {RUNTIME} -c "from packaging import tags; print(list(map(str,tags.sys_tags())))"',
+    shell=True,
 )
+valid_tags = {Tag(*t.split("-")) for t in eval(s.strip())}
+print(f"{len(valid_tags)} valid tags for {RUNTIME}.")
+
+packages = sorted(t["package"], key=lambda x: len(x["dependencies"]) if "dependencies" in x else 0)
 
 tag_selector = create_compatible_tags_selector(valid_tags)
 
@@ -75,11 +56,7 @@ for p in packages:
 
         found = False
 
-        wheels = list(
-            tag_selector(
-                (w, parse_wheel_filename(w["url"].split("/")[-1])[-1]) for w in wheels
-            )
-        )
+        wheels = list(tag_selector((w, parse_wheel_filename(w["url"].split("/")[-1])[-1]) for w in wheels))
 
         p.pop("wheels")
         if wheels:
@@ -91,9 +68,7 @@ for p in packages:
 
 root = next(p for p in packages if p["name"] == ROOT_PACKAGE)
 
-root["dependencies"] = [
-    dep for dep in root["dependencies"] if dep["name"] not in IGNORE_DEPS
-]
+root["dependencies"] = [dep for dep in root["dependencies"] if dep["name"] not in IGNORE_DEPS]
 
 markers = sorted(
     {
@@ -101,8 +76,7 @@ markers = sorted(
         for pac in packages
         for marker in [
             x["marker"]
-            for x in pac.get("dependencies", [])
-            + list(pac.get("optional-dependencies", {}).values())
+            for x in pac.get("dependencies", []) + list(pac.get("optional-dependencies", {}).values())
             if "marker" in x
         ]
     }
@@ -122,8 +96,8 @@ s = subprocess.check_output(
 )
 x = eval(s)
 
-markers = {marker for marker, valid in zip(markers, x, strict=True) if valid}
-
+markers = {marker for marker, valid in zip(markers, x, strict=True) if print(marker, valid) or valid}
+print()
 name_to_package = {p["name"]: p for p in packages}
 
 required_package_names = set()
@@ -131,25 +105,23 @@ visited_nodes = set()
 
 
 def resolve_dependencies(pkgname, extra=None):
-    # Track nodes as "pkg" or "pkg[extra]"
+    # Track as "pkg" or "pkg[extra]"
     node_id = f"{pkgname}[{extra}]" if extra else pkgname
 
     if node_id in visited_nodes:
         return
+
     visited_nodes.add(node_id)
     required_package_names.add(pkgname)
 
     pkg = name_to_package[pkgname]
 
-    # Look at base dependencies if no extra is specified,
-    # otherwise look in the specific optional-dependencies block.
     if extra is None:
         deps = pkg.get("dependencies", [])
     else:
         deps = pkg.get("optional-dependencies", {}).get(extra, [])
 
     for dep in deps:
-        # Check marker validity
         if "marker" in dep and dep["marker"] not in markers:
             continue
 
@@ -168,7 +140,7 @@ def resolve_dependencies(pkgname, extra=None):
 # Note: to build docs/tests, trigger resolve_dependencies(ROOT_PACKAGE, "docs")
 resolve_dependencies(ROOT_PACKAGE)
 
-# filter the master packages list
+# remove unnecessary packages
 packages = [p for p in packages if p["name"] in required_package_names]
 name_to_package = {p["name"]: p for p in packages}  # Update lookup
 
@@ -178,18 +150,15 @@ for pkg in packages:
     base_edges = [
         dep["name"]
         for dep in pkg.get("dependencies", [])
-        if ("marker" not in dep or dep["marker"] in markers)
-        and dep["name"] in required_package_names
+        if ("marker" not in dep or dep["marker"] in markers) and dep["name"] in required_package_names
     ]
-    # We must also include dependencies from extras if those extras were resolved for this package.
-    # We can check our `visited_nodes` to see if `pkg[extra]` was triggered.
+    # We must also include dependencies from extras if those extras were resolved for this package
     extra_edges = [
         dep["name"]
         for extra, extra_deps in pkg.get("optional-dependencies", {}).items()
         if f"{pkg['name']}[{extra}]" in visited_nodes
         for dep in extra_deps
-        if ("marker" not in dep or dep["marker"] in markers)
-        and dep["name"] in required_package_names
+        if ("marker" not in dep or dep["marker"] in markers) and dep["name"] in required_package_names
     ]
 
     all_deps[pkg["name"]] = base_edges + extra_edges
@@ -224,6 +193,8 @@ for pkg, deps in sorted_deps.items():
 
 
 def source_from_package(d: dict) -> dict:
+    # Once we have packages that use other forms of hashes
+    # (if possible???), then we must change this
     if "wheel" in d:
         return {
             "type": "file",
@@ -238,28 +209,24 @@ def source_from_package(d: dict) -> dict:
         }
 
 
-idx = 0
-source_list = []
-sources: dict[str, list[int]] = {}
-for pname, dependencies in sorted_deps.items():
+# I originally assumed the outputted modules needed source references from other modules, but
+# it turns out apparently modules are compiled sequentially and built against what already
+# exists so that's not necessary :
+
+source_ds: dict[str, dict] = {}
+for pname in sorted_deps:
     actual_package = name_to_package[pname]
 
     if pname != "blender-launcher-v2":
-        assert "sdist" in actual_package or "wheel" in actual_package
+        assert "wheel" in actual_package or "sdist" in actual_package, (
+            f'package {pname} has no "sdist" or "wheel" source (How did we get here?)'
+        )
 
-    sourc = [len(source_list)]
-    source_list.append(source_from_package(actual_package))
-    for dep in dependencies:
-        assert dep in sources
-        sourc.extend(sources[dep])
+    source_ds[pname] = source_from_package(actual_package)
 
-    sources[pname] = sourc
-
-
-import yaml
 
 modules = []
-for module, idxs in sources.items():
+for module, source in source_ds.items():
     name = f"{module}=={name_to_package[module]['version']}"
     d = {
         "name": f"python3-{module}",
@@ -279,7 +246,7 @@ for module, idxs in sources.items():
                 ]
             )
         ],
-        "sources": [source_list[idx] for idx in idxs],
+        "sources": [source],
     }
     modules.append(d)
 
@@ -290,10 +257,21 @@ d = {
     "modules": modules,
 }
 
+
+class IndentDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow, False)
+
+
+IndentDumper.add_representer(dict, lambda d, dat: d.represent_dict(dat.items()))
+
+
 with open(OUTPUT_PATH, "w") as output:
+    output.write("# Autogenerated with Blender-Launcher-V2/flatpak-files/generate_flatpak_modules.py\n")
     yaml.dump(
         d,
         output,
+        Dumper=IndentDumper,
         sort_keys=False,
     )
 

--- a/flatpak-files/generate_flatpak_modules.py
+++ b/flatpak-files/generate_flatpak_modules.py
@@ -88,7 +88,7 @@ markers = sorted(
 # TODO properly sanitize
 s = "\n".join(markers)
 s = subprocess.check_output(
-    f"""flatpak --arch=x86_64 --devel --command=python3 run io.qt.PySide.BaseApp \
+    f"""flatpak --arch=x86_64 --devel --command=python3 run {RUNTIME} \
     -c "from packaging.requirements import Marker; \
     print([Marker(x).evaluate() for x in \\"\\"\\"{s}\\"\\"\\".splitlines()])"
     """,
@@ -96,7 +96,7 @@ s = subprocess.check_output(
 )
 x = eval(s)
 
-markers = {marker for marker, valid in zip(markers, x, strict=True) if print(marker, valid) or valid}
+markers = {marker for marker, valid in zip(markers, x, strict=True) if valid}
 print()
 name_to_package = {p["name"]: p for p in packages}
 
@@ -177,15 +177,15 @@ while S:
     for edge in [e for e in edges if e[0] == n]:
         edges.remove(edge)
         if not any(e for e in edges if e[1] == edge[1]):
-            # S.appendleft(edge[1]) # most eager ordering
-            S.append(edge[1])  # least eager ordering
+            S.appendleft(edge[1])  # most eager ordering
+            # S.append(edge[1])  # least eager ordering
 
 
 sorted_deps = {p: all_deps[p] for p in L}
 sorted_deps.pop(ROOT_PACKAGE)
 
 leaves = [pkg for pkg, deps in sorted_deps.items() if not deps]
-print("Leaves: ", ", ".join(leaves))
+print("Leaves:", ", ".join(leaves))
 print("Dependencies:")
 for pkg, deps in sorted_deps.items():
     if deps:
@@ -208,10 +208,6 @@ def source_from_package(d: dict) -> dict:
             "sha256": d["sdist"]["hash"][d["sdist"]["hash"].index(":") + 1 :],
         }
 
-
-# I originally assumed the outputted modules needed source references from other modules, but
-# it turns out apparently modules are compiled sequentially and built against what already
-# exists so that's not necessary :
 
 source_ds: dict[str, dict] = {}
 for pname in sorted_deps:

--- a/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.desktop
+++ b/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Blender Launcher V2
+GenericName=Launcher
+Exec=/app/bin/BlenderLauncherV2 %U
+MimeType=application/x-blender;
+Icon=io.github.Victor_IX.Blender-Launcher-V2
+Terminal=false
+Type=Application
+Categories=Graphics;3DGraphics;

--- a/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.metainfo.xml
+++ b/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.metainfo.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<component type="desktop-application">
+  <id>io.github.Victor_IX.Blender-Launcher-V2</id>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+
+  <name>Blender Launcher V2</name>
+  <summary>
+    Manage Blender builds and its forks
+  </summary>
+  <developer id="io.github.victor_ix">
+    <name>Victor Chedeville</name>
+  </developer>
+
+  <description>
+    <p>Blender Launcher is a standalone software client that provides management for stable, daily and experimental builds of Blender and the popular forks Bforartists, and UPBGE.</p>
+    <p>The goal of Blender Launcher is to make it easier to stay up to date with the latest features and improvements of Blender.</p>
+
+    <p>It features:</p>
+    <ul>
+        <li>Installation of Blender stable, daily, branch, patch builds</li>
+        <li>Installation of BForartists stable builds</li>
+        <li>Installation of UPBGE stable and weekly builds</li>
+        <li>Build updating</li>
+        <li>A Tray context menu with fast-access for favorite builds</li>
+        <li>Template installation</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">
+    io.github.Victor_IX.Blender-Launcher-V2.desktop
+  </launchable>
+
+  <categories>
+    <category>Graphics</category>
+    <category>3DGraphics</category>
+  </categories>
+
+  <!-- Keywords? https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#categories-and-keywords -->
+
+  <!-- https://docs.flathub.org/banner-preview -->
+  <branding>
+    <color type="primary" scheme_preference="light">#b6c4ff</color>
+    <color type="primary" scheme_preference="dark">#503e6d</color>
+  </branding>
+
+  <content_rating type="oars-1.0" />
+
+  <url type="homepage">https://Victor-IX.github.io/Blender-Launcher-V2/</url>
+
+  <!-- TODO screenshots https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#screenshots -->
+  <!-- TODO releases https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#release -->
+  <!-- TODO Translations https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#translations   -->
+  <!-- Simply put, this wants us to be using `gettext` or `qt` formatting. this will be tricky to port... -->
+  <!-- TODO metainfo translations https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#metainfo-translations -->
+
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <!-- The minimum size of our window -->
+    <display_length compare="ge">640</display_length>
+  </supports>
+</component>

--- a/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.yml
+++ b/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.yml
@@ -43,7 +43,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/Victor-IX/Blender-Launcher-V2.git
-        commit: cea9e770
+        commit: 323d1af2ea91d03625b460b59d703ce50207375e
       - type: script
         dest-filename: run.sh
         commands:

--- a/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.yml
+++ b/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.yml
@@ -24,7 +24,11 @@ finish-args:
 
   # flatpak-spawn -- for launching blender
   - --talk-name=org.freedesktop.Flatpak
-  - --filesystem=host
+
+  # Common folders used for libraries
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+  - --filesystem=home
 
 modules:
   - python3-modules.yaml

--- a/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.yml
+++ b/flatpak-files/io.github.Victor_IX.Blender-Launcher-V2.yml
@@ -1,0 +1,63 @@
+id: io.github.Victor_IX.Blender-Launcher-V2
+sdk: org.kde.Sdk
+runtime: org.kde.Platform
+runtime-version: "6.10"
+base: io.qt.PySide.BaseApp
+base-version: "6.10"
+command: BlenderLauncherV2
+finish-args:
+  # X11 + XShm access
+  - --share=ipc
+  - --socket=fallback-x11
+  # Wayland access
+  - --socket=wayland
+  # Needs to talk to the network
+  - --share=network
+
+  # keyring
+  - --talk-name=org.freedesktop.secrets
+  # notifs
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.kde.kconfig.notify
+  - --talk-name=org.kde.KGlobalSettings
+
+  # flatpak-spawn -- for launching blender
+  - --talk-name=org.freedesktop.Flatpak
+  - --filesystem=host
+
+modules:
+  - python3-modules.yaml
+
+  - name: Blender-Launcher-V2
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 source/resources/icons/bl/bl_256.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
+      - python build_style.py
+      - install -Dm755 run.sh ${FLATPAK_DEST}/bin/BlenderLauncherV2
+      - cp -r source ${FLATPAK_DEST}/source
+    sources:
+      - type: git
+        url: https://github.com/Victor-IX/Blender-Launcher-V2.git
+        commit: cea9e770
+      - type: script
+        dest-filename: run.sh
+        commands:
+          - cd /app/
+          - python source/main.py $@
+
+  - name: blv2-desktop-file
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 ${FLATPAK_ID}.desktop -t ${FLATPAK_DEST}/share/applications
+    sources:
+      - type: file
+        path: io.github.Victor_IX.Blender-Launcher-V2.desktop
+
+  - name: blv2-metainfo
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
+    sources:
+      - type: file
+        path: io.github.Victor_IX.Blender-Launcher-V2.metainfo.xml

--- a/scripts/generate_flatpak_modules.py
+++ b/scripts/generate_flatpak_modules.py
@@ -1,0 +1,300 @@
+# ruff: noqa: E402
+
+# This generates the python3-modules.yaml file used in our flatpak packaging
+# via our `uv.lock`file.
+
+
+# The path to the lockfile used to resolve pip hashes and wheels.
+
+LOCKFILE_PATH = "uv.lock"
+OUTPUT_PATH = "python3-modules.yaml"
+
+# The name of the target package.
+ROOT_PACKAGE = "blender-launcher-v2"
+# Toplevel dependencies to ignore.
+IGNORE_DEPS = {
+    "pyinstaller",  # irrelevant
+    "pyside6-essentials",  # handled by io.qt.PySide.BaseApp
+    "pynput", # handled by external tools.
+}
+RUNTIME = "io.qt.PySide.BaseApp"
+
+import shlex
+import subprocess
+import tomllib
+from collections import deque
+from pathlib import Path
+
+try:
+    import yaml
+    from packaging.tags import Tag, create_compatible_tags_selector
+    from packaging.utils import parse_wheel_filename
+except ImportError:
+    print(
+        "Failed to import necessary modules. please install `PyYAML` and `packaging`."
+    )
+    print("`uv pip install PyYAML packaging`")
+
+
+with open(LOCKFILE_PATH, "rb") as f:
+    t = tomllib.load(f)
+    # We will probably have to rewrite parts of this if the revision changes
+    assert t["revision"] == 3
+
+# TODO sanitize output - serialize and deserialize?
+tags_path = Path("/tmp/flatpak-pyside-base-tags")
+if tags_path.exists():
+    valid_tags = {
+        Tag(*t.split("-"))
+        for t in eval(Path("/tmp/flatpak-pyside-base-tags").read_text())
+    }
+else:
+    with tags_path.open("wb") as f:
+        s = subprocess.check_output(
+            f'flatpak --arch=x86_64 --devel --command=python3 run {RUNTIME} -c "from packaging import tags; print(list(map(str,tags.sys_tags())))"',
+            shell=True,
+        )
+        print(s)
+        f.write(s)
+        valid_tags = {Tag(*t.split("-")) for t in eval(s.strip())}
+
+
+packages = sorted(
+    t["package"], key=lambda x: len(x["dependencies"]) if "dependencies" in x else 0
+)
+
+tag_selector = create_compatible_tags_selector(valid_tags)
+
+for p in packages:
+    p.pop("source")
+    if "sdist" in p:
+        p["sdist"].pop("size")
+        p["sdist"].pop("upload-time")
+    if "wheels" in p:
+        wheels = p["wheels"]
+
+        found = False
+
+        wheels = list(
+            tag_selector(
+                (w, parse_wheel_filename(w["url"].split("/")[-1])[-1]) for w in wheels
+            )
+        )
+
+        p.pop("wheels")
+        if wheels:
+            p["wheel"] = wheels[0]
+            wheels[0].pop("upload-time")
+            wheels[0].pop("size")
+            if "sdist" in p:
+                p.pop("sdist")
+
+root = next(p for p in packages if p["name"] == ROOT_PACKAGE)
+
+root["dependencies"] = [
+    dep for dep in root["dependencies"] if dep["name"] not in IGNORE_DEPS
+]
+
+markers = sorted(
+    {
+        marker
+        for pac in packages
+        for marker in [
+            x["marker"]
+            for x in pac.get("dependencies", [])
+            + list(pac.get("optional-dependencies", {}).values())
+            if "marker" in x
+        ]
+    }
+)
+
+
+# check with Flatpak which of these are valid
+#
+# TODO properly sanitize
+s = "\n".join(markers)
+s = subprocess.check_output(
+    f"""flatpak --arch=x86_64 --devel --command=python3 run io.qt.PySide.BaseApp \
+    -c "from packaging.requirements import Marker; \
+    print([Marker(x).evaluate() for x in \\"\\"\\"{s}\\"\\"\\".splitlines()])"
+    """,
+    shell=True,
+)
+x = eval(s)
+
+markers = {marker for marker, valid in zip(markers, x, strict=True) if valid}
+
+name_to_package = {p["name"]: p for p in packages}
+
+required_package_names = set()
+visited_nodes = set()
+
+
+def resolve_dependencies(pkgname, extra=None):
+    # Track nodes as "pkg" or "pkg[extra]"
+    node_id = f"{pkgname}[{extra}]" if extra else pkgname
+
+    if node_id in visited_nodes:
+        return
+    visited_nodes.add(node_id)
+    required_package_names.add(pkgname)
+
+    pkg = name_to_package[pkgname]
+
+    # Look at base dependencies if no extra is specified,
+    # otherwise look in the specific optional-dependencies block.
+    if extra is None:
+        deps = pkg.get("dependencies", [])
+    else:
+        deps = pkg.get("optional-dependencies", {}).get(extra, [])
+
+    for dep in deps:
+        # Check marker validity
+        if "marker" in dep and dep["marker"] not in markers:
+            continue
+
+        dep_name = dep["name"]
+
+        # Always resolve the base package of a dependency
+        resolve_dependencies(dep_name)
+
+        # If this dependency requests extras (e.g. "extra": ["yaml"]), resolve them too
+        requested_extras = dep.get("extra", []) or dep.get("extras", [])
+        for req_extra in requested_extras:
+            resolve_dependencies(dep_name, req_extra)
+
+
+# trigger the resolver on the root package
+# Note: to build docs/tests, trigger resolve_dependencies(ROOT_PACKAGE, "docs")
+resolve_dependencies(ROOT_PACKAGE)
+
+# filter the master packages list
+packages = [p for p in packages if p["name"] in required_package_names]
+name_to_package = {p["name"]: p for p in packages}  # Update lookup
+
+all_deps = {}
+for pkg in packages:
+    # Base dependencies
+    base_edges = [
+        dep["name"]
+        for dep in pkg.get("dependencies", [])
+        if ("marker" not in dep or dep["marker"] in markers)
+        and dep["name"] in required_package_names
+    ]
+    # We must also include dependencies from extras if those extras were resolved for this package.
+    # We can check our `visited_nodes` to see if `pkg[extra]` was triggered.
+    extra_edges = [
+        dep["name"]
+        for extra, extra_deps in pkg.get("optional-dependencies", {}).items()
+        if f"{pkg['name']}[{extra}]" in visited_nodes
+        for dep in extra_deps
+        if ("marker" not in dep or dep["marker"] in markers)
+        and dep["name"] in required_package_names
+    ]
+
+    all_deps[pkg["name"]] = base_edges + extra_edges
+
+
+# Sort the dependencies by build order
+# https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm
+edges = [(frm, to) for to, deps in all_deps.items() for frm in deps]
+L = []
+S = deque(p for p, deps in all_deps.items() if len(deps) == 0)
+
+while S:
+    n = S.popleft()
+    L.append(n)
+
+    for edge in [e for e in edges if e[0] == n]:
+        edges.remove(edge)
+        if not any(e for e in edges if e[1] == edge[1]):
+            # S.appendleft(edge[1]) # most eager ordering
+            S.append(edge[1])  # least eager ordering
+
+
+sorted_deps = {p: all_deps[p] for p in L}
+sorted_deps.pop(ROOT_PACKAGE)
+
+leaves = [pkg for pkg, deps in sorted_deps.items() if not deps]
+print("Leaves: ", ", ".join(leaves))
+print("Dependencies:")
+for pkg, deps in sorted_deps.items():
+    if deps:
+        print(f"{pkg} <- {', '.join(deps)}")
+
+
+def source_from_package(d: dict) -> dict:
+    if "wheel" in d:
+        return {
+            "type": "file",
+            "url": d["wheel"]["url"],
+            "sha256": d["wheel"]["hash"][d["wheel"]["hash"].index(":") + 1 :],
+        }
+    else:
+        return {
+            "type": "file",
+            "url": d["sdist"]["url"],
+            "sha256": d["sdist"]["hash"][d["sdist"]["hash"].index(":") + 1 :],
+        }
+
+
+idx = 0
+source_list = []
+sources: dict[str, list[int]] = {}
+for pname, dependencies in sorted_deps.items():
+    actual_package = name_to_package[pname]
+
+    if pname != "blender-launcher-v2":
+        assert "sdist" in actual_package or "wheel" in actual_package
+
+    sourc = [len(source_list)]
+    source_list.append(source_from_package(actual_package))
+    for dep in dependencies:
+        assert dep in sources
+        sourc.extend(sources[dep])
+
+    sources[pname] = sourc
+
+
+import yaml
+
+modules = []
+for module, idxs in sources.items():
+    name = f"{module}=={name_to_package[module]['version']}"
+    d = {
+        "name": f"python3-{module}",
+        "buildsystem": "simple",
+        "build-commands": [
+            " ".join(
+                [
+                    "pip3",
+                    "install",
+                    "--verbose",
+                    "--exists-action=i",
+                    "--no-index",
+                    '--find-links="file://${PWD}"',
+                    "--prefix=${FLATPAK_DEST}",
+                    shlex.quote(name),
+                    "--no-build-isolation",
+                ]
+            )
+        ],
+        "sources": [source_list[idx] for idx in idxs],
+    }
+    modules.append(d)
+
+d = {
+    "name": "python3-modules",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": modules,
+}
+
+with open(OUTPUT_PATH, "w") as output:
+    yaml.dump(
+        d,
+        output,
+        sort_keys=False,
+    )
+
+print(f"Wrote data to {OUTPUT_PATH}.")

--- a/source/main.py
+++ b/source/main.py
@@ -16,6 +16,7 @@ import modules._resources_rc  # noqa: F401
 import utils.i18n_init  # noqa: F401
 from modules import argument_parsing as ap
 from modules.cli_launching import cli_launch
+from modules.container_detect import IS_CONTAINED
 from modules.file_utils import retry_on_permission_error
 from modules.fonts import Fonts
 from modules.platform_utils import (
@@ -77,14 +78,16 @@ def main():
 
     subparsers = parser.add_subparsers(dest="command")
 
-    update_parser = subparsers.add_parser(
-        "update",
-        help="Update the application to a new version. Run 'update --help' to see available options.",
-        add_help=False,
-    )
-    add_help(update_parser)
-    update_parser.add_argument("version", help="Version to update to.", nargs="?")
-
+    if not IS_CONTAINED:
+        update_parser = subparsers.add_parser(
+            "update",
+            help="Update the application to a new version. Run 'update --help' to see available options.",
+            add_help=False,
+        )
+        add_help(update_parser)
+        update_parser.add_argument("version", help="Version to update to.", nargs="?")
+    else:
+        update_parser = None
     parser.add_argument("-d", "-debug", "--debug", help="Enable debug logging.", action="store_true")
     parser.add_argument("-set-library-folder", help="Set library folder", type=Path)
     parser.add_argument("-force-first-time", help="Force the first time setup", action="store_true")

--- a/source/modules/argument_parsing.py
+++ b/source/modules/argument_parsing.py
@@ -41,7 +41,9 @@ def show_help(
     else:
         if args.command == "update":
             if update_parser is None:
-                print("Update command called while in a contained environment. Please use your package manager's update functions.")
+                print(
+                    "Update command called while in a contained environment. Please use your package manager's update functions."
+                )
                 sys.exit(1)
             update_parser.print_help()
         elif args.command == "launch":

--- a/source/modules/argument_parsing.py
+++ b/source/modules/argument_parsing.py
@@ -26,12 +26,13 @@ def error(parser: ArgumentParser, msg: str):
 
 def show_help(
     parser: ArgumentParser,
-    update_parser: ArgumentParser,
+    update_parser: ArgumentParser | None,
     launch_parser: ArgumentParser,
     args: Namespace,
 ):
     if is_frozen() and sys.platform == "win32":
         if args.command == "update":
+            assert update_parser is not None
             show_windows_help(update_parser)
         elif args.command == "launch":
             show_windows_help(launch_parser)
@@ -39,6 +40,9 @@ def show_help(
             show_windows_help(parser)
     else:
         if args.command == "update":
+            if update_parser is None:
+                print("Update command called while in a contained environment. Please use your package manager's update functions.")
+                sys.exit(1)
             update_parser.print_help()
         elif args.command == "launch":
             launch_parser.print_help()

--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -699,12 +699,12 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
                     args = [b3d_exe.as_posix(), *blender_args.split(" ")]
 
     elif platform == "Linux":
+        from modules.container_detect import IS_FLATPAK
         bash_args = get_bash_arguments()
+        bash_args_ = shlex.split(bash_args)
 
-        if bash_args != "":
-            bash_args += " "
         if linux_nohup:
-            bash_args += "nohup"
+            bash_args_.append("nohup")
 
         cexe = info.custom_executable
         if cexe:
@@ -714,7 +714,12 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
         else:
             b3d_exe = library_folder / info.link / "blender"
 
-        args = f'{bash_args} "{b3d_exe.as_posix()}" {blender_args}'
+        if IS_FLATPAK:
+            # TODO add a check for bash_args to be a valid command
+            # ex. If it's just environment variables, instruct the user to use `env` in flatpak
+            args = f'flatpak-spawn --host {bash_args} "{shlex.quote(b3d_exe.as_posix())}" {blender_args}'
+        else:
+            args = f'{bash_args} "{shlex.quote(b3d_exe.as_posix())}" {blender_args}'
 
     elif platform == "macOS":
         # Check custom_executable first (for UPBGE, etc.)

--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -700,6 +700,7 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
 
     elif platform == "Linux":
         from modules.container_detect import IS_FLATPAK
+
         bash_args = get_bash_arguments()
         bash_args_ = shlex.split(bash_args)
 

--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -715,9 +715,7 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
             b3d_exe = library_folder / info.link / "blender"
 
         if IS_FLATPAK:
-            # TODO add a check for bash_args to be a valid command
-            # ex. If it's just environment variables, instruct the user to use `env` in flatpak
-            args = f'flatpak-spawn --host {bash_args} "{shlex.quote(b3d_exe.as_posix())}" {blender_args}'
+            args = f'flatpak-spawn --host --directory={shlex.quote(info.link)} {bash_args} "{shlex.quote(b3d_exe.as_posix())}" {blender_args}'
         else:
             args = f'{bash_args} "{shlex.quote(b3d_exe.as_posix())}" {blender_args}'
 

--- a/source/modules/container_detect.py
+++ b/source/modules/container_detect.py
@@ -1,0 +1,10 @@
+import os
+from pathlib import Path
+
+IS_FLATPAK = (
+    bool(os.getenv("container"))  # noqa: SIM112 (flatpak 'container' env variable is lowercase -~-)
+    or Path("/.flatpak-info").exists()
+)
+
+
+IS_CONTAINED = IS_FLATPAK # expand if necessary

--- a/source/modules/container_detect.py
+++ b/source/modules/container_detect.py
@@ -6,4 +6,4 @@ IS_FLATPAK = (
     or Path("/.flatpak-info").exists()
 )
 
-IS_CONTAINED = IS_FLATPAK # expand if necessary
+IS_CONTAINED = IS_FLATPAK  # expand if necessary

--- a/source/modules/container_detect.py
+++ b/source/modules/container_detect.py
@@ -6,5 +6,4 @@ IS_FLATPAK = (
     or Path("/.flatpak-info").exists()
 )
 
-
 IS_CONTAINED = IS_FLATPAK # expand if necessary

--- a/source/modules/container_detect.py
+++ b/source/modules/container_detect.py
@@ -1,9 +1,12 @@
 import os
 from pathlib import Path
 
+_DEBUG_IS_CONTAINED = "BLV2_CONTAINED" in os.environ
+
 IS_FLATPAK = (
     bool(os.getenv("container"))  # noqa: SIM112 (flatpak 'container' env variable is lowercase -~-)
     or Path("/.flatpak-info").exists()
 )
 
-IS_CONTAINED = IS_FLATPAK  # expand if necessary
+
+IS_CONTAINED = _DEBUG_IS_CONTAINED or IS_FLATPAK  # expand if necessary

--- a/source/modules/platform_utils.py
+++ b/source/modules/platform_utils.py
@@ -225,7 +225,7 @@ def get_default_library_folder():
         if app_bundle is not None:
             return app_bundle.parent
 
-    return get_cwd()
+    return Path("~/Documents/BlenderBuilds").expanduser()
 
 
 @cache

--- a/source/modules/platform_utils.py
+++ b/source/modules/platform_utils.py
@@ -210,6 +210,12 @@ def get_cwd():
     if is_frozen():
         return Path(os.path.dirname(sys.executable))
 
+    # TODO Opinionated -- discuss proper default working directory
+    from modules.container_detect import IS_CONTAINED
+
+    if IS_CONTAINED:
+        return Path.home()
+
     return Path.cwd()
 
 
@@ -218,7 +224,7 @@ def get_default_library_folder():
     """
     Get the default folder for library storage.
     On macOS with app bundles, returns the parent folder of the .app bundle.
-    Otherwise, returns get_cwd().
+    Otherwise, returns a place in ~/Documents.
     """
     if is_frozen() and get_platform() == "macOS":
         app_bundle = find_app_bundle(Path(sys.executable))

--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -13,6 +13,7 @@ from typing import TypeVar
 import keyring
 from keyring.errors import KeyringError, PasswordDeleteError
 from modules.bl_api_manager import dropdown_blender_version
+from modules.container_detect import IS_CONTAINED
 from modules.platform_utils import get_config_file, get_config_path, get_cwd, local_config, user_config
 from modules.version_matcher import VersionSearchQuery
 from PySide6.QtCore import QSettings
@@ -152,7 +153,10 @@ def get_actual_library_folder() -> Path:
     settings = get_settings()
     library_folder = settings.value("library_folder")
     if not is_library_folder_valid(library_folder):
-        library_folder = get_cwd()
+        if IS_CONTAINED:
+            library_folder = Path.home()
+        else:
+            library_folder = get_cwd()
 
     return Path(library_folder)
 

--- a/source/resources/localization/settings.en.yml
+++ b/source/resources/localization/settings.en.yml
@@ -349,4 +349,7 @@ blender_builds:
     DEFAULT: None
     Example: env __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia nohup
   bash_arguments: "Bash Arguments:"
+  bash_argument_warnings:
+    env_vars_in_flatpak: |
+        Environment variables detected while in a flatpak. To ensure these get captured, use the `env` command.
   startup_arguments: "Startup Arguments:"

--- a/source/threads/scraper.py
+++ b/source/threads/scraper.py
@@ -7,6 +7,7 @@ from time import localtime, mktime
 from typing import TYPE_CHECKING
 
 from modules.build_info import BuildInfo
+from modules.container_detect import IS_CONTAINED
 from modules.platform_utils import get_architecture, get_platform
 from modules.settings import (
     get_last_time_checked_utc,
@@ -78,9 +79,10 @@ class Scraper(QThread):
 
         self.get_download_links()
 
-        rel = self.launcher_data_updater.check_for_new_releases(self.current_version)
-        if rel is not None:
-            self.new_bl_version.emit(*rel)
+        if not IS_CONTAINED:
+            rel = self.launcher_data_updater.check_for_new_releases(self.current_version)
+            if rel is not None:
+                self.new_bl_version.emit(*rel)
 
     def scrapers(self):
         scrapers: list[BuildScraper] = []

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -21,6 +21,7 @@ from modules.build_info import (
     get_fork_config_paths,
     launch_build,
 )
+from modules.container_detect import IS_CONTAINED
 from modules.enums import MessageType
 from modules.file_utils import retry_on_permission_error
 from modules.fonts import Fonts
@@ -1038,6 +1039,8 @@ class LibraryWidget(BaseBuildWidget):
 
         if QDesktopServices.openUrl(QUrl.fromLocalFile(folder_path.as_posix())):
             return
+        elif IS_CONTAINED:
+            logger.error("QDesktopServices.openURL failed in a container! freezing is likely.")
 
         platform = get_platform()
 

--- a/source/windows/file_dialog_window.py
+++ b/source/windows/file_dialog_window.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+from modules.container_detect import IS_CONTAINED
 from PySide6.QtWidgets import QFileDialog, QWidget
 
 Option = QFileDialog.Option
+
+
+DIALOG_OPTIONS = Option.HideNameFilterDetails
+if not IS_CONTAINED:
+    DIALOG_OPTIONS |= Option.DontUseNativeDialog | Option.DontUseCustomDirectoryIcons
 
 
 class FileDialogWindow(QFileDialog):
@@ -10,12 +16,7 @@ class FileDialogWindow(QFileDialog):
         super().__init__()
 
     def get_directory(self, parent, title, directory):
-        options = (
-            Option.DontUseNativeDialog
-            | Option.ShowDirsOnly
-            | Option.HideNameFilterDetails
-            | Option.DontUseCustomDirectoryIcons
-        )
+        options = DIALOG_OPTIONS | Option.ShowDirsOnly
         return QFileDialog.getExistingDirectory(parent, title, directory, options)
 
     def get_open_filename(
@@ -28,7 +29,7 @@ class FileDialogWindow(QFileDialog):
             parent=parent,
             caption=title or "",
             dir=directory or "",
-            options=(Option.DontUseNativeDialog | Option.HideNameFilterDetails | Option.DontUseCustomDirectoryIcons),
+            options=DIALOG_OPTIONS,
         )
 
     def get_save_filename(
@@ -41,5 +42,5 @@ class FileDialogWindow(QFileDialog):
             parent=parent,
             caption=title or "",
             dir=directory or "",
-            options=(Option.DontUseNativeDialog | Option.HideNameFilterDetails | Option.DontUseCustomDirectoryIcons),
+            options=DIALOG_OPTIONS,
         )

--- a/source/windows/main_window/hotkey_handler.py
+++ b/source/windows/main_window/hotkey_handler.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from i18n import t
+from modules.container_detect import IS_CONTAINED
 from modules.settings import (
     get_quick_launch_key_seq,
 )
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     from .window import BlenderLauncher
 
 try:
+    if IS_CONTAINED:
+        raise AssertionError("Global hotkeys not supported in a containerized environment")
     from pynput import keyboard
 
     HOTKEYS_AVAILABLE = True

--- a/source/windows/main_window/hotkey_handler.py
+++ b/source/windows/main_window/hotkey_handler.py
@@ -15,13 +15,16 @@ if TYPE_CHECKING:
     from .window import BlenderLauncher
 
 try:
-    if IS_CONTAINED:
-        raise AssertionError("Global hotkeys not supported in a containerized environment")
     from pynput import keyboard
 
     HOTKEYS_AVAILABLE = True
 except Exception as e:
-    logging.exception(f"Error importing pynput: {e}\nGlobal hotkeys not supported.")
+    if IS_CONTAINED:
+        logging.warning("Global hotkeys disabled: Unsupported in a containerized environment")
+    else:
+        logging.exception("Global hotkeys disabled: Error importing pynput")
+        # Exception automatically printed
+
     HOTKEYS_AVAILABLE = False
 
 

--- a/source/windows/onboarding_window/window.py
+++ b/source/windows/onboarding_window/window.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from i18n import t
+from modules.container_detect import IS_CONTAINED
 from modules.platform_utils import get_platform
 from modules.settings import set_first_time_setup_seen
 from PySide6.QtCore import QThread, Signal
@@ -110,6 +111,10 @@ class OnboardingWindow(BaseWindow):
             AppearancePage(self.prop_settings, parent),
             BackgroundRunningPage(self.prop_settings, parent),
         ]
+
+        if IS_CONTAINED:
+            shortcuts_page = self.pages.pop(3)
+            del shortcuts_page
 
         for page in self.pages:
             self.wizard.addPage(page)

--- a/source/windows/onboarding_window/wizard_pages.py
+++ b/source/windows/onboarding_window/wizard_pages.py
@@ -134,52 +134,53 @@ class ChooseLibraryPage(BasicOnboardingPage):
 
         set_library_folder(str(pth))
 
-        if IS_CONTAINED:
+        if IS_CONTAINED or not is_frozen() or not self.move_exe.isChecked():
             return
 
-        if is_frozen() and self.move_exe.isChecked():  # move the executable to the library location
-            platform = get_platform()
+        # move the executable to the library location
 
-            if platform == "macOS":
-                # On macOS, we need to move the entire .app bundle
-                app_bundle = find_app_bundle(Path(sys.executable))
+        platform = get_platform()
 
-                if app_bundle is not None:
-                    # Move the entire .app bundle
-                    dest_app = pth / app_bundle.name
+        if platform == "macOS":
+            # On macOS, we need to move the entire .app bundle
+            app_bundle = find_app_bundle(Path(sys.executable))
 
-                    if dest_app.exists():
-                        return
+            if app_bundle is not None:
+                # Move the entire .app bundle
+                dest_app = pth / app_bundle.name
 
-                    self.prop_settings.exe_changed = True
-                    dest_app.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copytree(app_bundle, dest_app)
-
-                    # Update exe_location to point to the executable inside the moved .app
-                    # Maintain the same relative path from .app to executable
-                    relative_exe = Path(sys.executable).relative_to(app_bundle)
-                    self.prop_settings.exe_location = dest_app / relative_exe
-
-                    # Delete the original .app bundle immediately
-                    shutil.rmtree(app_bundle)
+                if dest_app.exists():
                     return
-                # If no .app bundle found, fall through to move just the executable
 
-            # Windows and Linux, or macOS without .app bundle
-            exe = pth / self.prop_settings.exe_location.name
-            self.prop_settings.exe_location = exe
+                self.prop_settings.exe_changed = True
+                dest_app.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(app_bundle, dest_app)
 
-            if exe.exists():
+                # Update exe_location to point to the executable inside the moved .app
+                # Maintain the same relative path from .app to executable
+                relative_exe = Path(sys.executable).relative_to(app_bundle)
+                self.prop_settings.exe_location = dest_app / relative_exe
+
+                # Delete the original .app bundle immediately
+                shutil.rmtree(app_bundle)
                 return
+            # If no .app bundle found, fall through to move just the executable
 
-            self.prop_settings.exe_changed = True
-            exe.parent.mkdir(parents=True, exist_ok=True)
-            retry_on_permission_error(shutil.copy, sys.executable, exe)
-            if platform == "Windows":  # delete the exe when closed
-                # self.launcher.delete_exe_on_reboot = True
-                ...
-            else:  # delete the executable directly
-                retry_on_permission_error(Path(sys.executable).unlink)
+        # Windows and Linux, or macOS without .app bundle
+        exe = pth / self.prop_settings.exe_location.name
+        self.prop_settings.exe_location = exe
+
+        if exe.exists():
+            return
+
+        self.prop_settings.exe_changed = True
+        exe.parent.mkdir(parents=True, exist_ok=True)
+        retry_on_permission_error(shutil.copy, sys.executable, exe)
+        if platform == "Windows":  # delete the exe when closed
+            # self.launcher.delete_exe_on_reboot = True
+            ...
+        else:  # delete the executable directly
+            retry_on_permission_error(Path(sys.executable).unlink)
 
 
 class RepoSelectPage(BasicOnboardingPage):

--- a/source/windows/onboarding_window/wizard_pages.py
+++ b/source/windows/onboarding_window/wizard_pages.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from i18n import t
+from modules.container_detect import IS_CONTAINED
 from modules.file_utils import retry_on_permission_error
-from modules.platform_utils import find_app_bundle, get_platform, is_frozen
+from modules.platform_utils import find_app_bundle, get_default_library_folder, get_platform, is_frozen
 from modules.settings import (
     get_actual_library_folder,
     get_actual_library_folder_no_fallback,
@@ -87,7 +88,7 @@ class ChooseLibraryPage(BasicOnboardingPage):
         self.launcher = parent
         self.lf = FolderSelector(
             parent,
-            default_folder=get_actual_library_folder_no_fallback() or Path("~/Documents/BlenderBuilds").expanduser(),
+            default_folder=get_actual_library_folder_no_fallback() or get_default_library_folder(),
             default_choose_dir_folder=get_actual_library_folder(),
             parent=self,
         )
@@ -116,7 +117,7 @@ class ChooseLibraryPage(BasicOnboardingPage):
         self.layout_.addWidget(self.warning_label)
         self.layout_.addWidget(QLabel(t("wizard.library.location"), self))
         self.layout_.addWidget(self.lf)
-        if home not in executable_path.parents:
+        if home not in executable_path.parents and not IS_CONTAINED:
             self.path_warning_label = QLabel(self)
             self.path_warning_label.setText(t("wizard.library.path_warning", home=str(home)))
             self.path_warning_label.setWordWrap(True)
@@ -132,6 +133,9 @@ class ChooseLibraryPage(BasicOnboardingPage):
         pth = Path(self.lf.line_edit.text())
 
         set_library_folder(str(pth))
+
+        if IS_CONTAINED:
+            return
 
         if is_frozen() and self.move_exe.isChecked():  # move the executable to the library location
             platform = get_platform()

--- a/source/windows/settings_window/blender_builds_tab.py
+++ b/source/windows/settings_window/blender_builds_tab.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from i18n import t
 from modules.bl_api_manager import dropdown_blender_version
+from modules.container_detect import IS_CONTAINED
 from modules.platform_utils import get_platform
 from modules.settings import (
     favorite_pages,
@@ -312,22 +313,22 @@ class BlenderBuildsTabWidget(SettingsFormWidget):
             )
 
         # Launching builds settings
-        with self.group("settings.blender_builds.launching_builds").contents.checked_hgroup(
-            "settings.blender_builds.quick_launch_global_shortcut",
-            default=get_enable_quick_launch_key_seq(),
-            setter=set_enable_quick_launch_key_seq,
-        ) as q:
-            # Quick Launch Key Sequence
-            self.QuickLaunchKeySeq = q.add(QLineEdit())
-            self.QuickLaunchKeySeq.keyPressEvent = self._keyPressEvent
-            self.QuickLaunchKeySeq.setText(str(get_quick_launch_key_seq()))
-            self.QuickLaunchKeySeq.setToolTip(t("settings.blender_builds.quick_launch_key_seq_tooltip"))
-            self.QuickLaunchKeySeq.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
-            self.QuickLaunchKeySeq.setCursorPosition(0)
-            self.QuickLaunchKeySeq.editingFinished.connect(self.update_quick_launch_key_seq)
-
-        # self.launching_settings = SettingsGroup(t("settings.blender_builds.launching_builds"), parent=self)
         with self.group("settings.blender_builds.launching_builds") as grp:
+            if not IS_CONTAINED:
+                with grp.checked_hgroup(
+                    "settings.blender_builds.quick_launch_global_shortcut",
+                    default=get_enable_quick_launch_key_seq(),
+                    setter=set_enable_quick_launch_key_seq,
+                ) as q:
+                    # Quick Launch Key Sequence
+                    self.QuickLaunchKeySeq = q.add(QLineEdit())
+                    self.QuickLaunchKeySeq.keyPressEvent = self._keyPressEvent
+                    self.QuickLaunchKeySeq.setText(str(get_quick_launch_key_seq()))
+                    self.QuickLaunchKeySeq.setToolTip(t("settings.blender_builds.quick_launch_key_seq_tooltip"))
+                    self.QuickLaunchKeySeq.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
+                    self.QuickLaunchKeySeq.setCursorPosition(0)
+                    self.QuickLaunchKeySeq.editingFinished.connect(self.update_quick_launch_key_seq)
+
             # On Blender Launch action
             self.OnBlenderLaunchAction = grp.add(
                 QComboBox(),

--- a/source/windows/settings_window/blender_builds_tab.py
+++ b/source/windows/settings_window/blender_builds_tab.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+import shlex
 from typing import TYPE_CHECKING
 
 from i18n import t
@@ -346,7 +348,7 @@ class BlenderBuildsTabWidget(SettingsFormWidget):
                 )
             else:
                 # Blender Startup Arguments
-                grp.add_label("settings.blender_builds.bash_arguments")
+                grp.add_label("settings.blender_builds.startup_arguments")
                 self.BlenderStartupArguments = grp.add(QLineEdit())
                 self.BlenderStartupArguments.setText(str(get_blender_startup_arguments()))
                 self.BlenderStartupArguments.setToolTip(t("settings.blender_builds.blender_startup_arguments_tooltip"))
@@ -355,13 +357,15 @@ class BlenderBuildsTabWidget(SettingsFormWidget):
                 self.BlenderStartupArguments.editingFinished.connect(self.update_blender_startup_arguments)
 
                 # Command Line Arguments
-                grp.add_label("settings.blender_builds.startup_arguments")
+                grp.add_label("settings.blender_builds.bash_arguments")
                 self.BashArguments = grp.add(QLineEdit())
                 self.BashArguments.setText(str(get_bash_arguments()))
                 self.BashArguments.setToolTip(t("settings.blender_builds.bash_arguments_tooltip"))
                 self.BashArguments.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
                 self.BashArguments.setCursorPosition(0)
                 self.BashArguments.editingFinished.connect(self.update_bash_arguments)
+                self.BashArgWarnings = grp.add_label("")
+                self.BashArguments.editingFinished.connect(self.validate_bash_args)
 
     def change_minimum_blender_stable_version(self, index: int):
         minimum = self.MinStableBlenderVer.itemText(index)
@@ -374,6 +378,19 @@ class BlenderBuildsTabWidget(SettingsFormWidget):
     def update_bash_arguments(self):
         args = self.BashArguments.text()
         set_bash_arguments(args)
+
+    def validate_bash_args(self):
+        args = self.BashArguments.text()
+        issues = []
+        from modules.container_detect import IS_FLATPAK
+
+        if IS_FLATPAK:
+            lex = shlex.shlex(args)
+            splitted_args = list(lex)
+            if re.fullmatch(r"[a-zA-Z_][a-zA-Z0-9_]*", splitted_args[0]) and splitted_args[1] == "=":
+                issues.append(t("settings.blender_builds.bash_argument_warnings.env_vars_in_flatpak"))
+
+        self.BashArgWarnings.setText("\n".join(issues).strip())
 
     def show_update_button(self, is_checked):
         self.UpdateBehavior.setEnabled(is_checked)

--- a/source/windows/settings_window/general_tab.py
+++ b/source/windows/settings_window/general_tab.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from i18n import t
+from modules.container_detect import IS_CONTAINED
 from modules.platform_utils import get_cache_path, get_platform
 from modules.settings import (
     delete_action,
@@ -122,23 +123,24 @@ class GeneralTabWidget(SettingsFormWidget):
 
                 spin.valueChanged.connect(warn_cpu_count)
 
-            # Pre-release builds
-            grp.add_checkbox(
-                "settings.general.app.prerelease",
-                default=get_use_pre_release_builds(),
-                setter=set_use_pre_release_builds,
-            )
+            if not IS_CONTAINED:
+                # Pre-release builds
+                grp.add_checkbox(
+                    "settings.general.app.prerelease",
+                    default=get_use_pre_release_builds(),
+                    setter=set_use_pre_release_builds,
+                )
 
-            # Create Shortcut
-            grp.add_button(
-                "settings.general.app.create_shortcut",
-                clicked=self.create_shortcut,
-                label_kwargs={
-                    "shortcut_type": t(
-                        f"settings.general.app.shortcut_type.{get_platform().lower()}",
-                    )
-                },
-            )
+                # Create Shortcut
+                grp.add_button(
+                    "settings.general.app.create_shortcut",
+                    clicked=self.create_shortcut,
+                    label_kwargs={
+                        "shortcut_type": t(
+                            f"settings.general.app.shortcut_type.{get_platform().lower()}",
+                        )
+                    },
+                )
 
         if get_config_file() != user_config():
             self.migrate_button = QPushButton(t("settings.general.migratel2u"), self)


### PR DESCRIPTION
**This adds some guards and conditions around the program for it to be runnable on Flatpak, and adds the required files to do so. (flatpak-files/).**

To test this, you need the `flatpak-builder` or `org.flatpak.Builder` program and to install:

```bash
uv run flatpak-files/generate_flatpak_modules.py
sh flatpak-files/build-and-install.sh
```

I got everything basic functional albeit with a few things intentionally missing such as global shortcuts and self-updating.

**Things I have tested:**

- Reading my existing library of builds
- Reloading custom builds
- Build downloading & installing
- Ensuring the launched builds have the same permissions since it should be launched on the host (GPU compute, filesystem scope)
- tray functions
- trash / delete (trashing seems to not be working but deleting is fine)

The metainfo.xml is somewhat incomplete, there are some TODOs at the bottom and we won't be able to just point them to this repo to submit it to flathub: [(Requirements)](https://docs.flathub.org/docs/for-app-authors/requirements#required-files) [(Submission Guidelines)](https://docs.flathub.org/docs/for-app-authors/submission). Submission will likely have to be handled by Victor.

---

The mentioned scopes in the manifest are just best guesses on where people would most likely want to place their library folders; Users can expose extra folders to our flatpak if it doesn't fit their needs via the commandline or Flatseal.

I may add a warning to the folder selection process if we detect that it is placed somewhere that portals give "temporary" access to, because in those scenarios the program struggles to spawn processes outside of the flatpak and other random issues.

related to: #74, #181, #209, every issue labeled "packaging related"