### PR TITLE
feat: add log level setting and open log folder button

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -19,7 +19,7 @@ from modules.cli_launching import cli_launch
 from modules.file_utils import retry_on_permission_error
 from modules.fonts import Fonts
 from modules.platform_utils import _popen, get_cache_path, get_cwd, get_launcher_name, get_platform, is_frozen
-from modules.settings import get_auto_register_winget
+from modules.settings import get_auto_register_winget, get_log_level
 from modules.shortcut import register_windows_filetypes, unregister_windows_filetypes
 from modules.uninstall import perform_uninstall
 from modules.version_matcher import VALID_FULL_QUERIES, VERSION_SEARCH_SYNTAX
@@ -43,7 +43,7 @@ _ = gettext.gettext
 # Setup logging
 setup_logging(
     log_path=get_cache_path().absolute() / "blender-launcher.log",
-    level="DEBUG" if "--debug" in sys.argv else "INFO",
+    level="DEBUG" if "--debug" in sys.argv else get_log_level(),
     max_bytes=1 * 1024 * 1024,  # 1 MB
     backup_count=2,
     format_string="[%(asctime)s:%(levelname)s] %(message)s",

--- a/source/main.py
+++ b/source/main.py
@@ -39,20 +39,9 @@ version = Version(
 
 
 _ = gettext.gettext
-
-# Setup logging
-setup_logging(
-    log_path=get_cache_path().absolute() / "blender-launcher.log",
-    level="DEBUG" if "--debug" in sys.argv else get_log_level(),
-    max_bytes=1 * 1024 * 1024,  # 1 MB
-    backup_count=2,
-    format_string="[%(asctime)s:%(levelname)s] %(message)s",
-)
-
 logger = logging.getLogger(__name__)
 
 
-# Setup exception handling
 def handle_exception(exc_type, exc_value, exc_traceback):
     if issubclass(exc_type, KeyboardInterrupt):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
@@ -62,9 +51,6 @@ def handle_exception(exc_type, exc_value, exc_traceback):
         f"{get_platform()} - Blender Launcher {version}",
         exc_info=(exc_type, exc_value, exc_traceback),
     )
-
-
-sys.excepthook = handle_exception
 
 
 def add_help(parser: ArgumentParser):
@@ -182,10 +168,14 @@ def main():
         ap.show_help(parser, update_parser, launch_parser, args)
         sys.exit(0)
 
-    if args.debug:
-        logging.root.setLevel(logging.DEBUG)
-    else:
-        logging.root.setLevel(logging.INFO)
+    setup_logging(
+        log_path=get_cache_path().absolute() / "blender-launcher.log",
+        level="DEBUG" if args.debug else get_log_level(),
+        max_bytes=1 * 1024 * 1024,  # 1 MB
+        backup_count=2,
+        format_string="[%(asctime)s:%(levelname)s] %(message)s",
+    )
+    sys.excepthook = handle_exception
 
     # Log Blender Launcher version
     logger.info(f"Blender Launcher Version: {version}")

--- a/source/modules/settings.py
+++ b/source/modules/settings.py
@@ -876,6 +876,20 @@ def set_use_pre_release_builds(b: bool):
     get_settings().setValue("use_pre_release_builds", b)
 
 
+log_levels = ("DEBUG", "INFO", "WARNING", "ERROR")
+
+
+def get_log_level() -> str:
+    v: str = get_settings().value("log_level", defaultValue="INFO", type=str)  # type: ignore
+    if v not in log_levels:
+        return "INFO"
+    return v
+
+
+def set_log_level(level: str):
+    get_settings().setValue("log_level", level)
+
+
 def get_use_system_titlebar() -> bool:
     return get_settings().value("use_system_title_bar", defaultValue=False, type=bool)  # type: ignore
 

--- a/source/resources/localization/settings.en.yml
+++ b/source/resources/localization/settings.en.yml
@@ -96,6 +96,18 @@ general:
     purge_temp_now_tooltip: |
         Immediately clear all files in the temporary download folder
 
+  logging:
+    label: Logging
+    log_level: Log Level
+    log_level_tooltip: |
+      Verbosity of messages written to blender-launcher.log.
+      Lower levels include more detail (DEBUG is the most verbose).
+      Requires a restart to take effect.
+      DEFAULT: INFO
+    open_log_folder: Open Log Folder
+    open_log_folder_tooltip: |
+      Open the folder containing blender-launcher.log in the system file manager.
+
 
 
 appearance:

--- a/source/resources/localization/settings.ja.yml
+++ b/source/resources/localization/settings.ja.yml
@@ -97,6 +97,18 @@ general:
     purge_temp_now_tooltip: |
         一時ダウンロードフォルダを即座に空にします
 
+  logging:
+    label: ログ
+    log_level: ログレベル
+    log_level_tooltip: |
+      blender-launcher.log に書き出すメッセージの詳細度を設定します。
+      レベルが低いほど詳細な情報が記録されます（DEBUGが最も詳細）。
+      反映するには再起動が必要です。
+      デフォルト: INFO
+    open_log_folder: ログフォルダを開く
+    open_log_folder_tooltip: |
+      blender-launcher.log のあるフォルダをファイルマネージャで開きます。
+
 
 
 appearance:

--- a/source/windows/settings_window/general_tab.py
+++ b/source/windows/settings_window/general_tab.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from i18n import t
-from modules.platform_utils import get_platform
+from modules.platform_utils import get_cache_path, get_platform
 from modules.settings import (
     delete_action,
     get_actual_library_folder,
@@ -17,10 +17,12 @@ from modules.settings import (
     get_launch_timer_duration,
     get_launch_when_system_starts,
     get_library_folder,
+    get_log_level,
     get_purge_temp_on_startup,
     get_show_tray_icon,
     get_use_pre_release_builds,
     get_worker_thread_count,
+    log_levels,
     migrate_config,
     set_auto_register_winget,
     set_default_delete_action,
@@ -29,6 +31,7 @@ from modules.settings import (
     set_launch_timer_duration,
     set_launch_when_system_starts,
     set_library_folder,
+    set_log_level,
     set_purge_temp_on_startup,
     set_show_tray_icon,
     set_use_pre_release_builds,
@@ -37,6 +40,8 @@ from modules.settings import (
 )
 from modules.shortcut import generate_program_shortcut, get_default_program_shortcut_destination
 from modules.winget_integration import register_with_winget, unregister_from_winget
+from PySide6.QtCore import QUrl
+from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QComboBox, QPushButton
 from threads.remover import purge_temp_folder
 from utils.i18n_init import Language
@@ -202,6 +207,18 @@ class GeneralTabWidget(SettingsFormWidget):
             # Purge Temp Now
             grp.add_button("settings.general.advanced.purge_temp_now", clicked=self.purge_temp_now)
 
+        # Logging
+        with self.group("settings.general.logging.label") as grp:
+            self.log_level_combo = grp.add(QComboBox(), "settings.general.logging.log_level")
+            for level in log_levels:
+                self.log_level_combo.addItem(level, level)
+            idx = self.log_level_combo.findData(get_log_level())
+            if idx >= 0:
+                self.log_level_combo.setCurrentIndex(idx)
+            self.log_level_combo.activated.connect(self.change_log_level)
+
+            grp.add_button("settings.general.logging.open_log_folder", clicked=self.open_log_folder)
+
     def prompt_library_folder(self):
         library_folder = str(get_library_folder())
         new_library_folder = FileDialogWindow().get_directory(self, t("msg.popup.select_library"), library_folder)
@@ -215,6 +232,13 @@ class GeneralTabWidget(SettingsFormWidget):
     def change_language(self, index: int):
         lang = self.language_combo.itemData(index)
         set_language(lang)
+
+    def change_log_level(self, index: int):
+        level = self.log_level_combo.itemData(index)
+        set_log_level(level)
+
+    def open_log_folder(self):
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(get_cache_path())))
 
     def library_folder_validity_changed(self, v: bool):
         if not v:

--- a/source/windows/settings_window/window.py
+++ b/source/windows/settings_window/window.py
@@ -4,6 +4,7 @@ from modules.settings import (
     get_dpi_scale_factor,
     get_enable_quick_launch_key_seq,
     get_language,
+    get_log_level,
     get_new_builds_check_frequency,
     get_proxy_host,
     get_proxy_password,
@@ -59,6 +60,7 @@ class SettingsWindow(BaseWindow):
         self.old_dpi_scale_factor = get_dpi_scale_factor()
         self.old_thread_count = get_worker_thread_count()
         self.old_language = get_language()
+        self.old_log_level = get_log_level()
 
         # Header layout
         self.header = WindowHeader(self, "Settings", use_minimize=False)
@@ -218,6 +220,14 @@ class SettingsWindow(BaseWindow):
 
         if self.old_language != language:
             pending_to_restart.append(f"{t('settings.general.app.language')}: {self.old_language}→{language}")
+
+        """Update log level"""
+        log_level = get_log_level()
+
+        if self.old_log_level != log_level:
+            pending_to_restart.append(
+                f"{t('settings.general.logging.log_level')}: {self.old_log_level}→{log_level}"
+            )
 
         return pending_to_restart
 


### PR DESCRIPTION
Follow-up to #420.

The reported Debug menu issue (#420) was hard to triage because there is currently no way for end users to switch the launcher to DEBUG logging without running it from a terminal with `--debug`.
The attached log therefore did not include `Running build with args ...` (a `logger.debug` call in `build_info.py`), so it was impossible to see what was actually passed to the launched process.

This adds a small **Logging** group to Settings → General:

- **Log Level** dropdown (DEBUG / INFO / WARNING / ERROR), persisted to `Blender Launcher.ini`. Follows the existing restart-required setting pattern (same UX as Language). `--debug` on the CLI still takes precedence when present.
- **Open Log Folder** button — opens the folder containing `blender-launcher.log` in the system file manager via `QDesktopServices` (works on Windows / macOS / Linux).

<img width="921" height="1046" alt="スクリーンショット 2026-06-02 0 31 34" src="https://github.com/user-attachments/assets/f56bb3a3-75ca-49cc-99b9-bf0d740180f0" />

