### PR TITLE
fix: defer tray menu popup on macOS so the app can quit

### DIFF
--- a/source/windows/main_window/tray_handler.py
+++ b/source/windows/main_window/tray_handler.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from i18n import t
 from modules.platform_utils import get_platform
-from PySide6.QtCore import QObject, Signal
+from PySide6.QtCore import QObject, QTimer, Signal
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QSystemTrayIcon
 from widgets.base_menu_widget import BaseMenuWidget
@@ -69,7 +69,11 @@ class TrayHandler(QObject):
             # INFO: Middle click dose not work anymore on new Windows versions with PyQt5
             # Middle click currently returns the Trigger reason
         elif reason == QSystemTrayIcon.ActivationReason.Context:
-            self.tray_menu.trigger()
+            if get_platform() == "macOS":
+                # Defer the macOS tray popup so Quit can exit properly.
+                QTimer.singleShot(0, self.tray_menu.trigger)
+            else:
+                self.tray_menu.trigger()
 
     def set_visible(self, b: bool):
         if b:


### PR DESCRIPTION
On macOS, quitting Blender Launcher from the menu bar (tray) icon's right-click menu did not actually terminate the app.
The process stayed alive (a white dot remained under the Dock icon) and had to be killed manually from Activity Monitor / Force Quit.

## Root cause

When the tray icon is right-clicked, AppKit runs a native status-item mouse-tracking loop:

    NSApplication.run()
      -> NSStatusBarButton rightMouseDown:
          -> trackMouse:inRect:ofView:untilMouseUp:   [native nested loop]

`TrayHandler.tray_icon_activated()` showed the context menu **synchronously** from inside this handler (`self.tray_menu.trigger()` -> `QMenu.exec_()`), i.e. while that native tracking loop was still running.
Popping up a Qt menu there prevents the native loop from unwinding cleanly.
Selecting **Quit** then calls `app.quit()` / `[NSApp stop]`, but `NSApplication.run()` never regains control to honor the stop request, so `app.exec()` never returns and the process keeps running.

This only reproduces in the bundled `.app` (where the tray uses a native `NSStatusItem`), which is why it wasn't visible when running from source.

A `sample` of the stuck process confirmed it was blocked inside `trackMouse:untilMouseUp:` waiting in `mach_msg`.
