### PR TITLE
fix: implement macOS self-update (app closed without relaunching)

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -282,8 +282,8 @@ def start_update(app: QApplication, is_instanced: bool, tag: str | None):
         bl_name, blu_name = get_launcher_name()
 
         if get_platform() == "macOS":
-            # The launcher is a .app bundle: copy the whole bundle next to the
-            # installed app with ditto, then relaunch it as the instanced updater.
+            # The launcher is a .app bundle: ditto copies the whole bundle, then
+            # relaunch it as the instanced updater.
             app_bundle = get_running_app_bundle()
             if app_bundle is None:
                 logger.error("Could not locate the running .app bundle; cannot self-update.")

--- a/source/main.py
+++ b/source/main.py
@@ -18,7 +18,16 @@ from modules import argument_parsing as ap
 from modules.cli_launching import cli_launch
 from modules.file_utils import retry_on_permission_error
 from modules.fonts import Fonts
-from modules.platform_utils import _popen, get_cache_path, get_cwd, get_launcher_name, get_platform, is_frozen
+from modules.platform_utils import (
+    _check_call,
+    _popen,
+    get_cache_path,
+    get_cwd,
+    get_launcher_name,
+    get_platform,
+    get_running_app_bundle,
+    is_frozen,
+)
 from modules.settings import get_auto_register_winget, get_log_level
 from modules.shortcut import register_windows_filetypes, unregister_windows_filetypes
 from modules.uninstall import perform_uninstall
@@ -270,18 +279,33 @@ def start_update(app: QApplication, is_instanced: bool, tag: str | None):
         sys.exit(app.exec())
     else:
         # Copy the launcher to the updater position
-        bl_exe, blu_exe = get_launcher_name()
+        bl_name, blu_name = get_launcher_name()
+
+        if get_platform() == "macOS":
+            # The launcher is a .app bundle: copy the whole bundle next to the
+            # installed app with ditto, then relaunch it as the instanced updater.
+            app_bundle = get_running_app_bundle()
+            if app_bundle is None:
+                logger.error("Could not locate the running .app bundle; cannot self-update.")
+                sys.exit(1)
+            updater_bundle = app_bundle.parent / blu_name
+            if updater_bundle.exists():
+                shutil.rmtree(updater_bundle, ignore_errors=True)
+            _check_call(["ditto", app_bundle.as_posix(), updater_bundle.as_posix()])
+            _popen(f'open -n "{updater_bundle.as_posix()}" --args --instanced update')
+            sys.exit(0)
+
         cwd = get_cwd()
-        source = cwd / bl_exe
-        dist = cwd / blu_exe
+        source = cwd / bl_name
+        dist = cwd / blu_name
         retry_on_permission_error(shutil.copy, source, dist)
 
         # Run the updater with the instanced flag
         if get_platform() == "Windows":
-            _popen([blu_exe, "--instanced", "update"])
+            _popen([blu_name, "--instanced", "update"])
         elif get_platform() == "Linux":
-            os.chmod(blu_exe, 0o744)
-            _popen(f'nohup "{blu_exe}" --instanced update')
+            os.chmod(blu_name, 0o744)
+            _popen(f'nohup "{blu_name}" --instanced update')
         sys.exit(0)
 
 

--- a/source/modules/platform_utils.py
+++ b/source/modules/platform_utils.py
@@ -37,6 +37,11 @@ def get_launcher_name() -> tuple[str, str]:
     if sys.platform == "win32":
         return ("Blender Launcher.exe", "Blender Launcher Updater.exe")
 
+    if sys.platform == "darwin":
+        # On macOS the launcher ships as a .app bundle, so the updater is a
+        # sibling bundle rather than a single file.
+        return ("Blender Launcher.app", "Blender Launcher Updater.app")
+
     return ("Blender Launcher", "Blender Launcher Updater")
 
 
@@ -193,6 +198,17 @@ def find_app_bundle(executable_path: Path) -> Path | None:
             return parent
 
     return None
+
+
+def get_running_app_bundle() -> Path | None:
+    """Return the .app bundle of the running process on macOS, else None.
+
+    Returns None when not on macOS or when the process is not running from a
+    .app bundle (e.g. running from source).
+    """
+    if get_platform() != "macOS":
+        return None
+    return find_app_bundle(Path(sys.executable))
 
 
 @cache

--- a/source/modules/platform_utils.py
+++ b/source/modules/platform_utils.py
@@ -38,8 +38,6 @@ def get_launcher_name() -> tuple[str, str]:
         return ("Blender Launcher.exe", "Blender Launcher Updater.exe")
 
     if sys.platform == "darwin":
-        # On macOS the launcher ships as a .app bundle, so the updater is a
-        # sibling bundle rather than a single file.
         return ("Blender Launcher.app", "Blender Launcher Updater.app")
 
     return ("Blender Launcher", "Blender Launcher Updater")
@@ -201,11 +199,7 @@ def find_app_bundle(executable_path: Path) -> Path | None:
 
 
 def get_running_app_bundle() -> Path | None:
-    """Return the .app bundle of the running process on macOS, else None.
-
-    Returns None when not on macOS or when the process is not running from a
-    .app bundle (e.g. running from source).
-    """
+    """Return the .app bundle of the running process on macOS, else None."""
     if get_platform() != "macOS":
         return None
     return find_app_bundle(Path(sys.executable))

--- a/source/threads/extractor.py
+++ b/source/threads/extractor.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import py7zr
 from modules.enums import MessageType
 from modules.file_utils import retry_on_permission_error
-from modules.platform_utils import _check_call, _check_output
+from modules.platform_utils import _check_call, _check_output, get_platform
 from modules.task import Task
 from PySide6.QtCore import Signal
 from send2trash import send2trash
@@ -27,6 +27,19 @@ def extract(source: Path, destination: Path, progress_callback: Callable[[int, i
             error_msg = f"File is not a valid zip file: {source}"
             logger.error(error_msg)
             raise zipfile.BadZipFile(error_msg)
+
+        if get_platform() == "macOS":
+            # macOS .app bundles must be extracted with ditto: Python's zipfile
+            # drops executable bits, symlinks, and resource forks, which leaves
+            # the extracted .app unable to launch. ditto preserves them.
+            with zipfile.ZipFile(source) as zf:
+                names = [m.filename for m in zf.infolist()]
+            folder = _get_build_folder(names) or names[0].split("/")[0]
+            destination.mkdir(parents=True, exist_ok=True)
+            progress_callback(0, 0)
+            _check_call(["ditto", "-x", "-k", source.as_posix(), destination.as_posix()])
+            progress_callback(1, 1)
+            return destination / folder
 
         try:
             with zipfile.ZipFile(source) as zf:

--- a/source/threads/extractor.py
+++ b/source/threads/extractor.py
@@ -29,9 +29,8 @@ def extract(source: Path, destination: Path, progress_callback: Callable[[int, i
             raise zipfile.BadZipFile(error_msg)
 
         if get_platform() == "macOS":
-            # macOS .app bundles must be extracted with ditto: Python's zipfile
-            # drops executable bits, symlinks, and resource forks, which leaves
-            # the extracted .app unable to launch. ditto preserves them.
+            # ditto preserves the .app's executable bits, symlinks and resource
+            # forks, which Python's zipfile drops (leaving the app unable to launch).
             with zipfile.ZipFile(source) as zf:
                 names = [m.filename for m in zf.infolist()]
             folder = _get_build_folder(names) or names[0].split("/")[0]

--- a/source/windows/main_window/window.py
+++ b/source/windows/main_window/window.py
@@ -21,11 +21,13 @@ from modules.connection_manager import ConnectionManager
 from modules.enums import MessageType
 from modules.file_utils import retry_on_permission_error
 from modules.platform_utils import (
+    _check_call,
     _popen,
     get_cwd,
     get_default_library_folder,
     get_launcher_name,
     get_platform,
+    get_running_app_bundle,
     is_frozen,
 )
 from modules.settings import (
@@ -492,13 +494,29 @@ class BlenderLauncher(BaseWindow):
 
             return
 
-        # Create copy of 'Blender Launcher.exe' file
-        # to act as an updater program
-        bl_exe, blu_exe = get_launcher_name()
+        # Create copy of the launcher to act as an updater program, so the
+        # original can be overwritten while the updater runs.
+        bl_name, blu_name = get_launcher_name()
+
+        if self.platform == "macOS":
+            # The launcher is a .app bundle: copy the whole bundle (ditto
+            # preserves perms/symlinks; shutil.copy cannot copy directories)
+            # next to the installed app, then launch it with `open`.
+            app_bundle = get_running_app_bundle()
+            if app_bundle is None:
+                logger.error("Could not locate the running .app bundle; cannot self-update.")
+                return
+            updater_bundle = app_bundle.parent / blu_name
+            if updater_bundle.exists():
+                shutil.rmtree(updater_bundle, ignore_errors=True)
+            _check_call(["ditto", app_bundle.as_posix(), updater_bundle.as_posix()])
+            _popen(f'open -n "{updater_bundle.as_posix()}" --args --instanced update {self.latest_tag}')
+            self.quit_()
+            return
 
         cwd = get_cwd()
-        source = cwd / bl_exe
-        dist = cwd / blu_exe
+        source = cwd / bl_name
+        dist = cwd / blu_name
 
         retry_on_permission_error(shutil.copy, source, dist)
 

--- a/source/windows/main_window/window.py
+++ b/source/windows/main_window/window.py
@@ -494,14 +494,13 @@ class BlenderLauncher(BaseWindow):
 
             return
 
-        # Create copy of the launcher to act as an updater program, so the
-        # original can be overwritten while the updater runs.
+        # Create a copy of the launcher to act as an updater program, so the
+        # original can be replaced while the updater runs.
         bl_name, blu_name = get_launcher_name()
 
         if self.platform == "macOS":
-            # The launcher is a .app bundle: copy the whole bundle (ditto
-            # preserves perms/symlinks; shutil.copy cannot copy directories)
-            # next to the installed app, then launch it with `open`.
+            # The launcher is a .app bundle: ditto copies the whole bundle
+            # (shutil.copy cannot copy directories), then launch it with `open`.
             app_bundle = get_running_app_bundle()
             if app_bundle is None:
                 logger.error("Could not locate the running .app bundle; cannot self-update.")

--- a/source/windows/update_window.py
+++ b/source/windows/update_window.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
+import shutil
 from typing import TypedDict
 
 import distro
-from modules.platform_utils import _popen, get_cwd, get_platform
+from modules.platform_utils import _check_call, _popen, get_cwd, get_platform, get_running_app_bundle
 from modules.tasks import TaskQueue
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
@@ -16,10 +18,22 @@ from threads.scraping.launcher_updates import get_release_tag
 from widgets.base_progress_bar_widget import BaseProgressBarWidget
 from windows.base_window import BaseWindow
 
-release_link = "https://github.com/Victor-IX/Blender-Launcher-V2/releases/download/{0}/Blender_Launcher_{0}_{1}_x64.zip"
+release_link = "https://github.com/Victor-IX/Blender-Launcher-V2/releases/download/{0}/Blender_Launcher_{0}_{1}.zip"
 api_link = "https://api.github.com/repos/Victor-IX/Blender-Launcher-V2/releases/tags/{}"
 
 logger = logging.getLogger()
+
+
+def release_asset_url(tag: str, platform: str) -> str:
+    """Build the GitHub release download URL for the launcher archive.
+
+    The release assets are named per the build workflows:
+      - Windows: ``Blender_Launcher_<tag>_Windows_x64.zip``
+      - macOS:   ``Blender_Launcher_<tag>_macos_arm64.zip`` (lowercase, arm64 only)
+    Linux is resolved separately via the GitHub API (distro-specific assets).
+    """
+    suffix = "macos_arm64" if platform == "macOS" else f"{platform}_x64"
+    return release_link.format(tag, suffix)
 
 
 # this only shows relevant sections of the response
@@ -61,6 +75,15 @@ class BlenderLauncherUpdater(BaseWindow):
         self.platform = get_platform()
         self.cwd = get_cwd()
 
+        # On macOS the updater runs from inside its own .app bundle, so get_cwd()
+        # (which is .../Updater.app/Contents/MacOS) is the wrong extraction target.
+        # The new .app must land next to the installed app instead.
+        self.install_dir = self.cwd
+        if self.platform == "macOS":
+            updater_bundle = get_running_app_bundle()
+            if updater_bundle is not None:
+                self.install_dir = updater_bundle.parent
+
         self.queue = TaskQueue(parent=self, worker_count=1)
         self.queue.start()
 
@@ -95,7 +118,7 @@ class BlenderLauncherUpdater(BaseWindow):
 
         release = asset_table.get("Ubuntu", asset_table.get("Linux"))
         if release is None:
-            return release_link.format(self.release_tag, self.platform)
+            return release_asset_url(self.release_tag, self.platform)
 
         for key in (
             distro.id().title(),
@@ -112,7 +135,7 @@ class BlenderLauncherUpdater(BaseWindow):
     def download(self):
         # TODO
         # This function should not use proxy for downloading new builds!
-        link = self.get_link() if self.platform == "Linux" else release_link.format(self.release_tag, self.platform)
+        link = self.get_link() if self.platform == "Linux" else release_asset_url(self.release_tag, self.platform)
 
         assert self.manager is not None
         self.ProgressBar.set_state(self.ProgressBar.State.DOWNLOADING)
@@ -124,7 +147,15 @@ class BlenderLauncherUpdater(BaseWindow):
     def extract(self, source):
         self.ProgressBar.set_state(self.ProgressBar.State.EXTRACTING)
         self.source_zip = source
-        a = ExtractTask(source, self.cwd)
+
+        # On macOS, remove the previous .app so ditto writes a clean bundle
+        # instead of merging into stale files. The original app has already quit.
+        if self.platform == "macOS":
+            target = self.install_dir / "Blender Launcher.app"
+            if target.exists():
+                shutil.rmtree(target, ignore_errors=True)
+
+        a = ExtractTask(source, self.install_dir)
         a.progress.connect(self.ProgressBar.set_progress)
         a.finished.connect(self.finish)
         self.queue.append(a)
@@ -137,13 +168,25 @@ class BlenderLauncherUpdater(BaseWindow):
             except Exception as e:
                 logger.warning(f"Failed to remove temporary file {self.source_zip}: {e}")
 
-        # Launch 'Blender Launcher.exe' and exit
+        # Launch the freshly installed launcher and exit
         launcher = str(dist)
         if self.platform == "Windows":
             _popen([launcher])
         elif self.platform == "Linux":
             os.chmod(dist, 0o744)
             _popen('nohup "' + launcher + '"')
+        elif self.platform == "macOS":
+            # Self-downloaded files are not quarantined, but strip the attribute
+            # defensively so Gatekeeper never blocks the relaunch.
+            with contextlib.suppress(Exception):
+                _check_call(["xattr", "-dr", "com.apple.quarantine", launcher])
+            # -n forces a new instance: the updater shares the new app's bundle
+            # id, so without -n `open` would just re-activate this updater.
+            _popen(f'open -n "{launcher}"')
+            # Best-effort detached cleanup of this updater bundle copy.
+            updater_bundle = get_running_app_bundle()
+            if updater_bundle is not None:
+                _popen(f'sleep 3 && rm -rf "{updater_bundle.as_posix()}"')
 
         self.app.quit()
 

--- a/source/windows/update_window.py
+++ b/source/windows/update_window.py
@@ -25,13 +25,7 @@ logger = logging.getLogger()
 
 
 def release_asset_url(tag: str, platform: str) -> str:
-    """Build the GitHub release download URL for the launcher archive.
-
-    The release assets are named per the build workflows:
-      - Windows: ``Blender_Launcher_<tag>_Windows_x64.zip``
-      - macOS:   ``Blender_Launcher_<tag>_macos_arm64.zip`` (lowercase, arm64 only)
-    Linux is resolved separately via the GitHub API (distro-specific assets).
-    """
+    # macOS releases are published as "macos_arm64", everything else as "<Platform>_x64"
     suffix = "macos_arm64" if platform == "macOS" else f"{platform}_x64"
     return release_link.format(tag, suffix)
 
@@ -75,9 +69,8 @@ class BlenderLauncherUpdater(BaseWindow):
         self.platform = get_platform()
         self.cwd = get_cwd()
 
-        # On macOS the updater runs from inside its own .app bundle, so get_cwd()
-        # (which is .../Updater.app/Contents/MacOS) is the wrong extraction target.
-        # The new .app must land next to the installed app instead.
+        # On macOS get_cwd() is inside the updater's own .app bundle, so the new
+        # app must be installed next to it instead.
         self.install_dir = self.cwd
         if self.platform == "macOS":
             updater_bundle = get_running_app_bundle()
@@ -148,14 +141,17 @@ class BlenderLauncherUpdater(BaseWindow):
         self.ProgressBar.set_state(self.ProgressBar.State.EXTRACTING)
         self.source_zip = source
 
-        # On macOS, remove the previous .app so ditto writes a clean bundle
-        # instead of merging into stale files. The original app has already quit.
+        dest = self.install_dir
         if self.platform == "macOS":
-            target = self.install_dir / "Blender Launcher.app"
-            if target.exists():
-                shutil.rmtree(target, ignore_errors=True)
+            # Extract into a staging folder so the installed app is only replaced
+            # once extraction succeeds (a failed update never deletes it).
+            self.staging_dir = self.install_dir / ".bl_update"
+            if self.staging_dir.exists():
+                shutil.rmtree(self.staging_dir, ignore_errors=True)
+            self.staging_dir.mkdir(parents=True, exist_ok=True)
+            dest = self.staging_dir
 
-        a = ExtractTask(source, self.install_dir)
+        a = ExtractTask(source, dest)
         a.progress.connect(self.ProgressBar.set_progress)
         a.finished.connect(self.finish)
         self.queue.append(a)
@@ -176,19 +172,34 @@ class BlenderLauncherUpdater(BaseWindow):
             os.chmod(dist, 0o744)
             _popen('nohup "' + launcher + '"')
         elif self.platform == "macOS":
-            # Self-downloaded files are not quarantined, but strip the attribute
-            # defensively so Gatekeeper never blocks the relaunch.
+            launcher = str(self._install_macos_app(dist))
             with contextlib.suppress(Exception):
                 _check_call(["xattr", "-dr", "com.apple.quarantine", launcher])
-            # -n forces a new instance: the updater shares the new app's bundle
-            # id, so without -n `open` would just re-activate this updater.
+            # -n forces a new instance; the updater shares the new app's bundle id
             _popen(f'open -n "{launcher}"')
-            # Best-effort detached cleanup of this updater bundle copy.
             updater_bundle = get_running_app_bundle()
             if updater_bundle is not None:
                 _popen(f'sleep 3 && rm -rf "{updater_bundle.as_posix()}"')
 
         self.app.quit()
+
+    def _install_macos_app(self, new_app):
+        # Swap the staged app in for the installed one only after a successful
+        # extraction, restoring the previous version if the swap itself fails.
+        target = self.install_dir / new_app.name
+        old = self.install_dir / f"{new_app.name}.old"
+        shutil.rmtree(old, ignore_errors=True)
+        if target.exists():
+            target.rename(old)
+        try:
+            new_app.rename(target)
+        except OSError:
+            logger.exception("Failed to install update; restoring previous version")
+            if not target.exists() and old.exists():
+                old.rename(target)
+        shutil.rmtree(old, ignore_errors=True)
+        shutil.rmtree(self.staging_dir, ignore_errors=True)
+        return target
 
     def closeEvent(self, event):
         self.queue.fullstop()

--- a/tests/backend/test_self_update.py
+++ b/tests/backend/test_self_update.py
@@ -1,0 +1,41 @@
+"""Tests for the launcher self-update asset resolution and naming.
+
+These guard against the macOS regression where the download URL was built as
+``..._macOS_x64.zip`` while the release workflow publishes ``..._macos_arm64.zip``.
+"""
+
+import sys
+
+import pytest
+
+from source.modules import platform_utils
+from source.windows.update_window import release_asset_url
+
+
+def test_release_asset_url_windows_matches_workflow():
+    # windows_release.yml publishes Blender_Launcher_<tag>_Windows_x64.zip
+    url = release_asset_url("v2.7.3", "Windows")
+    assert url.endswith("/v2.7.3/Blender_Launcher_v2.7.3_Windows_x64.zip")
+
+
+def test_release_asset_url_macos_matches_workflow():
+    # macos_release.yml publishes Blender_Launcher_<tag>_macos_arm64.zip (lowercase)
+    url = release_asset_url("v2.7.3", "macOS")
+    assert url.endswith("/v2.7.3/Blender_Launcher_v2.7.3_macos_arm64.zip")
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "expected"),
+    [
+        ("win32", ("Blender Launcher.exe", "Blender Launcher Updater.exe")),
+        ("darwin", ("Blender Launcher.app", "Blender Launcher Updater.app")),
+        ("linux", ("Blender Launcher", "Blender Launcher Updater")),
+    ],
+)
+def test_get_launcher_name_per_platform(monkeypatch, platform_name, expected):
+    monkeypatch.setattr(sys, "platform", platform_name)
+    platform_utils.get_launcher_name.cache_clear()
+    try:
+        assert platform_utils.get_launcher_name() == expected
+    finally:
+        platform_utils.get_launcher_name.cache_clear()

--- a/tests/backend/test_self_update.py
+++ b/tests/backend/test_self_update.py
@@ -1,9 +1,3 @@
-"""Tests for the launcher self-update asset resolution and naming.
-
-These guard against the macOS regression where the download URL was built as
-``..._macOS_x64.zip`` while the release workflow publishes ``..._macos_arm64.zip``.
-"""
-
 import sys
 
 import pytest


### PR DESCRIPTION
## Problem

On macOS, clicking **Update** in the launcher-update notification closes the app and nothing comes back up — the user stays on the old version. The self-update flow (`show_update_window()` → updater process → relaunch) only had branches for Windows and Linux, so on macOS it copied the launcher, matched neither branch, and quit silently.

Several gaps compounded this:

1. **`show_update_window()`** (`windows/main_window/window.py`) and **`start_update()`** (`main.py`) had no macOS branch, so the updater was never launched.
2. **`finish()`** (`windows/update_window.py`) had no macOS branch, so the new version was never relaunched.
3. **Wrong download URL**: releases publish `Blender_Launcher_<tag>_macos_arm64.zip`, but the template built `Blender_Launcher_<tag>_macOS_x64.zip` (case + arch mismatch → 404).
4. **Extraction**: the `.zip` path used Python's `zipfile`, which drops executable bits, symlinks, and resource forks — leaving the extracted `.app` unable to launch.
5. **`get_launcher_name()`** returned a bare name, but on macOS the launcher is a `.app` bundle and `get_cwd()` points *inside* it.

## Fix

End-to-end macOS self-update, mirroring the Windows/Linux model but bundle-aware:

- Copy the running `.app` with `ditto` to a sibling `Blender Launcher Updater.app`, then relaunch it via `open -n … --args --instanced update <tag>` (`shutil.copy` can't copy directories; `-n` forces a new instance since the copy shares the bundle id).
- The updater extracts into the **install dir** (next to the `.app`) instead of `get_cwd()` (which is inside the updater bundle), removes the stale `.app` first, relaunches the new `.app` with `open -n`, then cleans up its own bundle copy.
- Fix the asset URL via a new `release_asset_url()` helper (`macos_arm64`, lowercase).
- Extract macOS `.app` zips with `ditto` to preserve bundle integrity.
- `get_launcher_name()` returns `.app` names on macOS; add `get_running_app_bundle()` helper.

## Tests

Adds `tests/backend/test_self_update.py` covering the asset-URL naming (guards the exact `macOS_x64` vs `macos_arm64` regression) and per-platform launcher names. New tests pass; the rest of the suite is unchanged (one pre-existing unrelated failure in `test_get_args` exists on `main`).

## Notes / limitations

- The fix lands in future releases — a user on an already-broken build must update manually once.
- The macOS release is **unsigned/not notarized and arm64-only** (`.github/workflows/macos_release.yml`), so Intel Macs have no compatible asset. Out of scope here, but worth tracking.
- The end-to-end relaunch can only be fully verified from a built `.app` downloading a real tagged release; logic was verified by reading the flow and unit-testing the pure pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)