### PR TITLE
fix: update button stuck in "updating" state after same-version update

### DIFF
--- a/source/widgets/download_widget.py
+++ b/source/widgets/download_widget.py
@@ -372,9 +372,14 @@ class DownloadWidget(BaseBuildWidget):
 
     def successful_read_callback(self, widget: LibraryWidget):
         self.setInstalled(widget)
-        if self.updating_widget is not None and not self._is_removed:
+        if self.updating_widget is not None:
             updating_widget = self.updating_widget
-            if updating_widget.move_portable_settings:
+            if self._is_removed:
+                # The new build reused the old one's folder name, so there is no
+                # separate old build to remove.
+                updating_widget.update_finished()
+                self.updating_widget = None
+            elif updating_widget.move_portable_settings:
                 logger.debug("Transferring portable settings...")
                 QTimer.singleShot(500, lambda: self.handle_portable_settings(updating_widget, widget))
             else:


### PR DESCRIPTION
Fixes a bug where the button stays stuck showing "updating" and never returns to its normal state after an update, even though the new build is installed correctly.

## When it happens

This occurs when updating to a build whose version number is unchanged and only the hash or commit time differs. As a result, it is especially common with daily / weekly / experimental builds, where updates often share the same version number.

## After the fix

In this case the button now correctly returns from the "updating" state to its normal state once the update completes.
