### PR TITLE
feat: add Blender to PATH on macOS via /etc/paths.d/

### DIFF
--- a/source/resources/localization/act.en.yml
+++ b/source/resources/localization/act.en.yml
@@ -94,6 +94,8 @@ a:
 
   register: Register Extension
   register_tooltip: Use this build for .blend files and to display thumbnails
+  register_macos: Add Blender to PATH
+  register_tooltip_macos: "Add this build to PATH via /etc/paths.d/ (requires admin password)"
   shortcut: Create Shortcut
   symlink: Create Symlink
   template: Install Template

--- a/source/resources/localization/act.es.yml
+++ b/source/resources/localization/act.es.yml
@@ -62,6 +62,8 @@ a:
 
   register: Registrar extensión
   register_tooltip: Usar esta versión para archivos .blend y para mostrar miniaturas
+  register_macos: Agregar Blender al PATH
+  register_tooltip_macos: "Agregar esta versión al PATH mediante /etc/paths.d/ (requiere contraseña de administrador)"
   shortcut: Crear acceso directo
   symlink: Crear enlace simbólico
   template: Instalar plantilla

--- a/source/resources/localization/act.fr.yml
+++ b/source/resources/localization/act.fr.yml
@@ -91,6 +91,8 @@ a:
 
   register: Enregistrer l'extension
   register_tooltip: Utiliser ce build pour les fichiers .blend et afficher les miniatures
+  register_macos: Ajouter Blender au PATH
+  register_tooltip_macos: "Ajouter ce build au PATH via /etc/paths.d/ (mot de passe administrateur requis)"
   shortcut: Créer un raccourci
   symlink: Créer un lien symbolique
   template: Installer un modèle

--- a/source/resources/localization/act.ja.yml
+++ b/source/resources/localization/act.ja.yml
@@ -94,6 +94,8 @@ a:
 
   register: 拡張機能を登録
   register_tooltip: このビルドを.blendファイルとサムネイル表示に使用する
+  register_macos: BlenderをPATHに追加
+  register_tooltip_macos: "/etc/paths.d/ 経由でこのビルドをPATHに追加します（管理者パスワードが必要）"
   shortcut: ショートカットを作成
   symlink: シンボリックリンクを作成
   template: テンプレートをインストール

--- a/source/resources/localization/act.zh.yml
+++ b/source/resources/localization/act.zh.yml
@@ -91,6 +91,8 @@ a:
 
   register: 注册扩展
   register_tooltip: 将此构建版本用于.blend文件并显示缩略图
+  register_macos: 将Blender添加到PATH
+  register_tooltip_macos: "通过 /etc/paths.d/ 将此版本添加到PATH（需要管理员密码）"
   shortcut: 创建快捷方式
   symlink: 创建符号链接
   template: 安装模板

--- a/source/threads/register.py
+++ b/source/threads/register.py
@@ -1,3 +1,4 @@
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -8,6 +9,8 @@ from PySide6.QtCore import QThread
 
 if sys.platform == "win32":
     from subprocess import CREATE_NO_WINDOW
+
+_MACOS_PATHS_D_FILE = "/etc/paths.d/blender-launcher"
 
 
 class Register(QThread):
@@ -30,3 +33,29 @@ class Register(QThread):
             )
         elif platform == "Linux":
             b3d_exe = Path(self.path) / "blender"
+        elif platform == "macOS":
+            macos_dir = _find_macos_dir(Path(self.path))
+            if macos_dir is not None:
+                _write_paths_d(str(macos_dir))
+
+
+def _find_macos_dir(path: Path) -> Path | None:
+    """Find the Contents/MacOS directory inside the Blender .app bundle."""
+    candidates = [
+        path / "Blender.app" / "Contents" / "MacOS",
+        path / "Blender" / "Blender.app" / "Contents" / "MacOS",
+        path / "Bforartists.app" / "Contents" / "MacOS",
+        path / "Bforartists" / "Bforartists.app" / "Contents" / "MacOS",
+    ]
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _write_paths_d(macos_dir: str) -> None:
+    """Write the Blender binary directory to /etc/paths.d/blender-launcher via osascript."""
+    shell_cmd = f"echo {shlex.quote(macos_dir)} > {_MACOS_PATHS_D_FILE}"
+    applescript_str = shell_cmd.replace("\\", "\\\\").replace('"', '\\"')
+    script = f'do shell script "{applescript_str}" with administrator privileges'
+    subprocess.call(["osascript", "-e", script], stdout=PIPE, stderr=STDOUT)

--- a/source/widgets/library_widget.py
+++ b/source/widgets/library_widget.py
@@ -216,8 +216,12 @@ class LibraryWidget(BaseBuildWidget):
         self.fetchPrNameAction = QAction(t("act.a.fetch_pr_name"))
         self.fetchPrNameAction.triggered.connect(self.fetch_pr_name)
 
-        self.registerExtentionAction = QAction(t("act.a.register"))
-        self.registerExtentionAction.setToolTip(t("act.a.register_tooltip"))
+        if get_platform() == "macOS":
+            self.registerExtentionAction = QAction(t("act.a.register_macos"))
+            self.registerExtentionAction.setToolTip(t("act.a.register_tooltip_macos"))
+        else:
+            self.registerExtentionAction = QAction(t("act.a.register"))
+            self.registerExtentionAction.setToolTip(t("act.a.register_tooltip"))
         self.registerExtentionAction.triggered.connect(self.register_extension)
 
         self.createShortcutAction = QAction(t("act.a.shortcut"))
@@ -281,7 +285,7 @@ class LibraryWidget(BaseBuildWidget):
 
         self.menu.addSeparator()
 
-        if get_platform() == "Windows":
+        if get_platform() in {"Windows", "macOS"}:
             self.menu.addAction(self.registerExtentionAction)
 
         self.menu.addAction(self.createShortcutAction)


### PR DESCRIPTION
fixed: #427 

Added a process that elevates to administrator privileges via AppleScript to append Blender's path to `/etc/paths.d/blender-launcher` .

<img width="825" height="697" src="https://github.com/user-attachments/assets/8a3d9d18-35d9-45d3-b57f-1fc30ef9dda0" />
