### PR TITLE
Update documentation paths to include all subdirectories

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
       - master
       - main
     paths:
-      - "docs/*"
+      - "docs/**"
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
A single asterisk means it will only monitor changes in that toplevel directory. two asterisks includes all subdirectories. The current uploaded documentation is still from v2.7.2