### PR TITLE
Open Bforartists release notes on GitHub releases page

### DIFF
--- a/source/widgets/base_build_widget.py
+++ b/source/widgets/base_build_widget.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import abc
-import logging
 import re
-from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 from i18n import t
@@ -12,16 +10,12 @@ from PySide6 import QtCore
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QAction, QDesktopServices
 from PySide6.QtWidgets import QWidget
-from threads.scraping.bfa import BFA_NC_WEBDAV_SHARE_TOKEN, BFA_NC_WEBDAV_URL, get_bfa_nc_https_download_url
-from webdav4.client import Client
 from widgets.base_menu_widget import BaseMenuWidget
 
 if TYPE_CHECKING:
     from items.base_list_widget_item import BaseListWidgetItem
     from modules.build_info import BuildInfo
     from windows.main_window import BlenderLauncher
-
-logger = logging.getLogger()
 
 
 class BaseBuildWidget(QWidget):
@@ -57,18 +51,9 @@ class BaseBuildWidget(QWidget):
             QDesktopServices.openUrl(f"https://www.blender.org/download/lts/#lts-release-{v}")
         elif self.build_info.branch == "bforartists":
             ver = self.build_info.semversion
-            client = Client(BFA_NC_WEBDAV_URL, auth=(BFA_NC_WEBDAV_SHARE_TOKEN, ""))
-            try:
-                entries = client.ls(
-                    f"/Bforartists {ver.major}.{ver.minor}.{ver.patch}", detail=True, allow_listing_resource=True
-                )
-                for e in entries:
-                    if isinstance(e, dict) and "name" in e:
-                        path = PurePosixPath(e["name"])
-                        if "releasenote" in path.name.lower():
-                            QDesktopServices.openUrl(get_bfa_nc_https_download_url(path))
-            except Exception:
-                logger.exception("Failed get Bforartists release note")
+            QDesktopServices.openUrl(
+                f"https://github.com/Bforartists/Bforartists/releases/tag/v{ver.major}.{ver.minor}.{ver.patch}"
+            )
         else:
             # Open for builds with D12345 name pattern
             # Extract only D12345 substring


### PR DESCRIPTION
fixed #445 

I changed the URL for the bforartists release notes to GitHub Releases. The NextCloud release notes, which are the same as the main application download destination, are downloaded instead of displayed in the browser, so I am using GitHub Releases.
We have not changed the download location of the main application to GitHub because it might hit the API rate limit.