### PR TITLE
fix: launch blend files stored on network (UNC) paths on Windows

### DIFF
--- a/source/modules/build_info.py
+++ b/source/modules/build_info.py
@@ -666,6 +666,14 @@ class LaunchWithBlendFile(LaunchMode):
 class LaunchOpenLast(LaunchMode): ...
 
 
+def path_arg(pth: Path) -> str:
+    # Windows keeps native separators here: as_posix() would turn a UNC path like
+    # \\NAS\project\file.blend into //NAS/..., which Blender reads as relative to the blend file.
+    if get_platform() == "Windows":
+        return str(pth)
+    return pth.as_posix()
+
+
 def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, linux_nohup=True) -> list[str] | str:
     platform = get_platform()
     library_folder = get_library_folder()
@@ -676,7 +684,7 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
     if platform == "Windows":
         if exe is not None:
             b3d_exe = library_folder / info.link / exe
-            args = ["cmd", "/C", b3d_exe.as_posix()]
+            args = ["cmd", "/C", path_arg(b3d_exe)]
         else:
             cexe = info.custom_executable
             if cexe:
@@ -690,14 +698,14 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
             # Check if the executable is a batch file and needs cmd /C
             if b3d_exe.suffix.lower() in (".bat", ".cmd"):
                 if blender_args == "":
-                    args = ["cmd", "/C", b3d_exe.as_posix()]
+                    args = ["cmd", "/C", path_arg(b3d_exe)]
                 else:
-                    args = ["cmd", "/C", b3d_exe.as_posix(), *blender_args.split(" ")]
+                    args = ["cmd", "/C", path_arg(b3d_exe), *blender_args.split(" ")]
             else:
                 if blender_args == "":
-                    args = [b3d_exe.as_posix()]
+                    args = [path_arg(b3d_exe)]
                 else:
-                    args = [b3d_exe.as_posix(), *blender_args.split(" ")]
+                    args = [path_arg(b3d_exe), *blender_args.split(" ")]
 
     elif platform == "Linux":
         bash_args = get_bash_arguments()
@@ -754,10 +762,11 @@ def get_args(info: BuildInfo, exe=None, launch_mode: LaunchMode | None = None, l
 
     if launch_mode is not None:
         if isinstance(launch_mode, LaunchWithBlendFile):
+            blendfile = path_arg(launch_mode.blendfile)
             if isinstance(args, list):
-                args.append(launch_mode.blendfile.as_posix())
+                args.append(blendfile)
             else:
-                args += f' "{launch_mode.blendfile.as_posix()}"'
+                args += f' "{blendfile}"'
         elif isinstance(launch_mode, LaunchOpenLast):
             if isinstance(args, list):
                 args.append("--open-last")

--- a/tests/backend/test_build_parser.py
+++ b/tests/backend/test_build_parser.py
@@ -49,7 +49,7 @@ def test_parser():
 )
 def test_get_args():
     root = os.path.abspath(os.sep)
-    win_root = root.replace("\\", "")
+    win_root = root.rstrip("\\")
     info = BuildInfo(os.path.join(root, "blender"), "4.0.0", "ffffffff", datetime.datetime(2024, 12, 12), "daily")  # noqa: DTZ001
     info_c = BuildInfo(
         os.path.join(root, "blender"),
@@ -69,37 +69,37 @@ def test_get_args():
     x = [
         (
             get_args(info=info),
-            [win_root + "/blender/blender.exe"],
+            [win_root + "\\blender\\blender.exe"],
             'nohup "/blender/blender" ',
             "open -W -n /blender/Blender/Blender.app --args",
         ),
         (
             get_args(info=info, linux_nohup=False),
-            [win_root + "/blender/blender.exe"],
+            [win_root + "\\blender\\blender.exe"],
             ' "/blender/blender" ',
             "open -W -n /blender/Blender/Blender.app --args",
         ),
         (
             get_args(info=info, exe="bforartists.exe"),
-            ["cmd", "/C", win_root + "/blender/bforartists.exe"],
+            ["cmd", "/C", win_root + "\\blender\\bforartists.exe"],
             'nohup "/blender/blender" ',
             "open -W -n /blender/Blender/Blender.app --args",
         ),
         (
             get_args(info=info_c),
-            [win_root + "/blender/bforartists"],
+            [win_root + "\\blender\\bforartists"],
             'nohup "/blender/bforartists" ',
             "open -W -n /blender/Blender/Blender.app --args",
         ),
         (
             get_args(info=info, launch_mode=LaunchOpenLast()),
-            [win_root + "/blender/blender.exe", "--open-last"],
+            [win_root + "\\blender\\blender.exe", "--open-last"],
             'nohup "/blender/blender"  --open-last',
             "open -W -n /blender/Blender/Blender.app --args --open-last",
         ),
         (
             get_args(info=info, launch_mode=LaunchWithBlendFile(Path(root) / "file.blend")),
-            [win_root + "/blender/blender.exe", win_root + "/file.blend"],
+            [win_root + "\\blender\\blender.exe", win_root + "\\file.blend"],
             'nohup "/blender/blender"  "/file.blend"',
             'open -W -n /blender/Blender/Blender.app --args --open-last "/file.blend"',
         ),


### PR DESCRIPTION
## Summary

Fixes #144.

`get_args()` formatted every path passed to Blender with `Path.as_posix()`.
On Windows, `as_posix()` turns a UNC path like `\\NAS\project\file.blend`
into `//NAS/project/file.blend`. Blender reserves a leading `//` for paths
relative to the blend file (`BLI_path_is_rel`), so it expanded the argument
against the launcher's CWD, failed to find the file, and silently opened the
default scene instead — matching the behavior reported in the issue (file
association and drag-and-drop from a NAS both went through this code path).

Verified against a real UNC path with a local Blender build:

```
# old (as_posix): //NAS/.../probe.blend
Error: Cannot read file "D:\...\NAS\...\probe.blend": No such file or directory

# new (native separators): \\NAS\...\probe.blend
Read blend: "\\NAS\...\probe.blend"
```

## Change

Added `path_arg()` in `build_info.py`, which keeps native separators on
Windows and leaves every other platform on `as_posix()` (unchanged there).
Used it for both the blend file argument and the executable path, since the
library folder itself can also live on a share.

## Test plan

- [x] `pytest tests/backend/test_build_parser.py` (updated Windows-branch
      expectations to native separators)
- [x] Full `pytest tests/` suite passes
- [x] `ruff check` / `ruff format --check` pass
- [x] Manual: built with PyInstaller, launched a `.blend` file over a UNC
      path (`\\localhost\C$\...`), confirmed Blender opens the correct file
      instead of the default scene
      